### PR TITLE
chore(naming): make presentation more clean

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "Fastify",
+        "pino"
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
 import config from '@infrastructure/config/index.js';
 import logger from '@infrastructure/logging/index.js';
-import HttpServer from '@presentation/http/http-server.js';
+import API from '@presentation/index.js';
 import runMetricsServer from '@infrastructure/metrics/index.js';
 
-
-const httpServer = new HttpServer(config.httpApi);
+const ApiInstance = new API(config.httpApi);
 
 const start = async (): Promise<void> => {
   try {
-    await httpServer.run();
+    await ApiInstance.run();
 
     if (config.metrics.enabled) {
       await runMetricsServer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ import logger from '@infrastructure/logging/index.js';
 import API from '@presentation/index.js';
 import runMetricsServer from '@infrastructure/metrics/index.js';
 
-const ApiInstance = new API(config.httpApi);
+const apiInstance = new API(config.httpApi);
 
 const start = async (): Promise<void> => {
   try {
-    await ApiInstance.run();
+    await apiInstance.run();
 
     if (config.metrics.enabled) {
       await runMetricsServer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ import logger from '@infrastructure/logging/index.js';
 import API from '@presentation/index.js';
 import runMetricsServer from '@infrastructure/metrics/index.js';
 
-const apiInstance = new API(config.httpApi);
+const api = new API(config.httpApi);
 
 const start = async (): Promise<void> => {
   try {
-    await apiInstance.run();
+    await api.run();
 
     if (config.metrics.enabled) {
       await runMetricsServer();

--- a/src/presentation/api.interface.ts
+++ b/src/presentation/api.interface.ts
@@ -1,0 +1,9 @@
+/**
+ * API interface
+ */
+export default interface API {
+  /**
+   * Runs API module
+   */
+  run(): Promise<void>;
+}

--- a/src/presentation/http/http-server.ts
+++ b/src/presentation/http/http-server.ts
@@ -1,7 +1,7 @@
 import { getLogger } from '@infrastructure/logging/index.js';
 import { HttpApiConfig } from '@infrastructure/config/index.js';
 import fastify from 'fastify';
-import type API from '../api.interface.js';
+import type API from '@presentation/api.interface.js';
 import NoteRouter from '@presentation/http/router/note.js';
 
 const appServerLogger = getLogger('appServer');

--- a/src/presentation/http/http-server.ts
+++ b/src/presentation/http/http-server.ts
@@ -1,7 +1,7 @@
 import { getLogger } from '@infrastructure/logging/index.js';
 import { HttpApiConfig } from '@infrastructure/config/index.js';
 import fastify from 'fastify';
-import { Server } from '../server.js';
+import type API from '../api.interface.js';
 import NoteRouter from '@presentation/http/router/note.js';
 
 const appServerLogger = getLogger('appServer');
@@ -9,7 +9,7 @@ const appServerLogger = getLogger('appServer');
 /**
  * Http server implementation
  */
-export default class HttpServer implements Server {
+export default class HttpServer implements API {
   /**
    * Fastify server instance
    */

--- a/src/presentation/index.ts
+++ b/src/presentation/index.ts
@@ -1,0 +1,6 @@
+import HttpServer from './http/http-server.js';
+
+/**
+ * Current API implementation
+ */
+export default HttpServer;

--- a/src/presentation/server.ts
+++ b/src/presentation/server.ts
@@ -1,9 +1,0 @@
-/**
- * Server interface
- */
-export interface Server {
-    /**
-     * Runs server
-     */
-    run(): Promise<void>;
-}


### PR DESCRIPTION
1. Entry point shouldn't know about what presentation server is used, only about interface.
2. Presentation Server renamed to API
3. EditorConfig added
4. Spellcheck error fixed