### PR TITLE
chore(oauth): use postmessage instead of cookies for oauth callback

### DIFF
--- a/src/presentation/http/router/oauth.ts
+++ b/src/presentation/http/router/oauth.ts
@@ -66,20 +66,21 @@ const OauthRouter: FastifyPluginCallback<OauthRouterOptions> = (fastify, opts, d
     const refreshToken = await opts.authService.signRefreshToken(user.id);
 
     /**
-     * Set tokens to cookies and redirect to referer
+     * Show page with script passing parent window postMessage with tokens
      */
-    reply.setCookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      path: '/',
-      domain: opts.cookieDomain,
-    }).setCookie('accessToken', accessToken, {
-      httpOnly: true,
-      path: '/',
-      domain: opts.cookieDomain,
-    })
-      .redirect(referer);
-
-    reply.redirect(referer);
+    reply.type('text/html').send(`
+      <html>
+        <head>
+          <script>
+            window.opener.postMessage({ accessToken: '${accessToken}', refreshToken: '${refreshToken}' }, '${referer}');
+            window.close();
+          </script>
+        </head>
+        <body>
+          <p>You are awesome! ᕕ( ͡° ͜ʖ ͡°)ᕗ</p>
+        </body>
+      </html>
+    `);
   });
   done();
 };

--- a/src/repository/storage/postgres/orm/sequelize/index.ts
+++ b/src/repository/storage/postgres/orm/sequelize/index.ts
@@ -42,7 +42,7 @@ export default class SequelizeOrm {
       await this.conn.authenticate();
       databaseLogger.info(`Database connected to ${this.conn.config.host}:${this.conn.config.port}`);
     } catch (error) {
-      databaseLogger.error('Unable to connect to the database:', error);
+      databaseLogger.error(error);
     }
   }
 


### PR DESCRIPTION
- The callback route will be opened in a popup by Web App
- So we just send tokens via a postMessage to the "opener" window 
- Then, close a window