### PR TITLE
feat(router): note id resolver

### DIFF
--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -1,4 +1,4 @@
-import type { Note, NotePublicId } from '@domain/entities/note.js';
+import type { Note, NoteInternalId, NotePublicId } from '@domain/entities/note.js';
 import type NoteRepository from '@repository/note.repository.js';
 import { createPublicId } from '@infrastructure/utils/id.js';
 
@@ -54,13 +54,33 @@ export default class NoteService {
   }
 
   /**
-   * Gets note by id
+   * Returns note by id
    *
-   * @param id - note id
-   * @returns { Promise<Note | null> } note
+   * @param id - note internal id
    */
-  public async getNoteById(id: NotePublicId): Promise<Note | null> {
-    return await this.repository.getNoteByPublicId(id);
+  public async getNoteById(id: NoteInternalId): Promise<Note> {
+    const note = await this.repository.getNoteById(id);
+
+    if (note === null) {
+      throw new Error(`Note with id ${id} was not found`);
+    }
+
+    return note;
+  }
+
+  /**
+   * Returns note by public id
+   *
+   * @param publicId - note public id
+   */
+  public async getNoteByPublicId(publicId: NotePublicId): Promise<Note> {
+    const note = await this.repository.getNoteByPublicId(publicId);
+
+    if (note === null) {
+      throw new Error(`Note with public id ${publicId} was not found`);
+    }
+
+    return note;
   }
 
   /**

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -36,15 +36,13 @@ export default class NoteService {
   }
 
   /**
-   * Updates note
+   * Updates a note
    *
-   * @param id - note id
+   * @param id - note internal id
    * @param content - new content
-   * @returns updated note
-   * @throws { Error } if note was not updated
    */
-  public async updateNoteContentByPublicId(id: NotePublicId, content: Note['content']): Promise<Note> {
-    const updatedNote = await this.repository.updateNoteContentByPublicId(id, content);
+  public async updateNoteContentById(id: NoteInternalId, content: Note['content']): Promise<Note> {
+    const updatedNote = await this.repository.updateNoteContentById(id, content);
 
     if (updatedNote === null) {
       throw new Error(`Note with id ${id} was not updated`);

--- a/src/domain/service/noteSettings.ts
+++ b/src/domain/service/noteSettings.ts
@@ -1,4 +1,4 @@
-import type { Note, NotePublicId } from '@domain/entities/note.js';
+import type { NoteInternalId } from '@domain/entities/note.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
 import type NoteSettingsRepository from '@repository/noteSettings.repository.js';
 
@@ -21,25 +21,11 @@ export default class NoteSettingsService {
   }
 
   /**
-   * Gets note settings by public id
+   * Returns settings for a note with passed id
    *
-   * @param id - note public id
-   * @returns { Promise<NoteSettings | null> } note settings
+   * @param id - note internal id
    */
-  public async getNoteSettingsByPublicId(id: NotePublicId): Promise<NoteSettings> {
-    /**
-     * @todo get internal id by public id and resolve note settings by the internal id
-     */
-    return await this.repository.getNoteSettingsByPublicId(id);
-  }
-
-  /**
-   * Gets note settings by note id
-   *
-   * @param id - note id
-   * @returns { Promise<NoteSettings | null> } note
-   */
-  public async getNoteSettingsByNoteId(id: Note['id']): Promise<NoteSettings | null> {
+  public async getNoteSettingsByNoteId(id: NoteInternalId): Promise<NoteSettings> {
     return await this.repository.getNoteSettingsByNoteId(id);
   }
 
@@ -48,9 +34,9 @@ export default class NoteSettingsService {
    *
    * @param noteId - note id
    * @param enabled - is note enabled
-   * @returns { Promise<NoteSettings> } note settings
+   * @returns added note settings
    */
-  public async addNoteSettings(noteId: Note['id'], enabled: boolean = true): Promise<NoteSettings> {
+  public async addNoteSettings(noteId: NoteInternalId, enabled: boolean = true): Promise<NoteSettings> {
     return await this.repository.addNoteSettings({
       noteId: noteId,
       enabled: enabled,
@@ -60,13 +46,13 @@ export default class NoteSettingsService {
   /**
    * Partially updates note settings
    *
+   * @param noteId - note internal id
    * @param data - note settings data with new values
-   * @param noteId - note public id
-   * @returns { Promise<NoteSettings> } updated note settings
+   * @returns updated note settings
    */
-  public async patchNoteSettingsByPublicId(data: Partial<NoteSettings>, noteId: NotePublicId): Promise<NoteSettings | null> {
-    const noteSettings = await this.repository.getNoteSettingsByPublicId(noteId);
+  public async patchNoteSettingsByNoteId(noteId: NoteInternalId, data: Partial<NoteSettings>): Promise<NoteSettings | null> {
+    const noteSettings = await this.repository.getNoteSettingsByNoteId(noteId);
 
-    return await this.repository.patchNoteSettingsByPublicId(data, noteSettings.id);
+    return await this.repository.patchNoteSettingsById(noteSettings.id, data);
   }
 }

--- a/src/infrastructure/utils/hasProperty.ts
+++ b/src/infrastructure/utils/hasProperty.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if passed variable is an object and has a property with passed name
+ *
+ * @param obj - object to check
+ * @param name - property name
+ */
+export default function hasProperty<Obj, Name extends string>(obj: Obj, name: Name): obj is Obj & Record<Name, unknown> {
+  return typeof obj === 'object' && obj !== null && name in obj;
+}

--- a/src/presentation/http/fastify.d.ts
+++ b/src/presentation/http/fastify.d.ts
@@ -55,10 +55,17 @@ declare module 'fastify' {
   }
 
   /**
-   * Augment FastifyRequest to add userId property.
-   * This property added by Auth Middleware
+   * Augment FastifyRequest to respect properties added by middlewares
    */
   export interface FastifyRequest {
-    userId: AuthPayload['id'] | null
+    /**
+     * This property added by userIdResolver middleware
+     */
+    userId: AuthPayload['id'] | null;
+
+    /**
+     * This property added by noteIdResolver middleware
+     */
+    noteId: number | undefined;
   }
 }

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -8,7 +8,7 @@ import cors from '@fastify/cors';
 import fastifyOauth2 from '@fastify/oauth2';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUI from '@fastify/swagger-ui';
-import addAuthMiddleware from '@presentation/http/middlewares/auth.js';
+import addUserIdResolver from '@presentation/http/middlewares/common/userIdResolver.js';
 import cookie from '@fastify/cookie';
 import NotFoundDecorator from './decorators/notFound.js';
 import NoteRouter from '@presentation/http/router/note.js';
@@ -69,7 +69,7 @@ export default class HttpApi implements Api {
     await this.addOauth2();
     await this.addCORS();
 
-    this.addMiddlewares(domainServices);
+    this.addCommonMiddlewares(domainServices);
 
     this.addSchema();
     this.addDecorators();
@@ -249,12 +249,12 @@ export default class HttpApi implements Api {
    *
    * @param domainServices - instances of domain services
    */
-  private addMiddlewares(domainServices: DomainServices): void {
+  private addCommonMiddlewares(domainServices: DomainServices): void {
     if (this.server === undefined) {
       throw new Error('Server is not initialized');
     }
 
-    addAuthMiddleware(this.server, domainServices.authService, appServerLogger);
+    addUserIdResolver(this.server, domainServices.authService, appServerLogger);
   }
 
   /**

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -171,6 +171,7 @@ export default class HttpApi implements Api {
     await this.server?.register(NoteSettingsRouter, {
       prefix: '/note-settings',
       noteSettingsService: domainServices.noteSettingsService,
+      noteService: domainServices.noteService,
     });
 
     await this.server?.register(OauthRouter, {

--- a/src/presentation/http/middlewares/common/userIdResolver.ts
+++ b/src/presentation/http/middlewares/common/userIdResolver.ts
@@ -10,7 +10,7 @@ import notEmpty from '@infrastructure/utils/notEmpty.js';
  * @param authService - auth domain service
  * @param logger - logger instance
  */
-export default function addAuthMiddleware(server: FastifyInstance, authService: AuthService, logger: typeof Logger ): void {
+export default function addUserIdResolver(server: FastifyInstance, authService: AuthService, logger: typeof Logger ): void {
   /**
    * Default userId value — null
    */

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -42,19 +42,11 @@ export default function useNoteResolver(noteService: NoteService): {
       let note: Note | undefined;
 
       try {
-        switch (request.method) {
-          case 'GET':
-            note = await resolveNoteByPublicId(request.params);
-            break;
-          case 'POST':
-            note = await resolveNoteByPublicId(request.params);
-            break;
-          case 'PUT':
-          case 'PATCH':
-          case 'DELETE':
-            note = await resolveNoteByPublicId(request.body);
-            break;
-        }
+        /**
+         * All methods (GET, POST, PATCH, etc) could have note public id just in route params,
+         * so we don't check for query and body at the moment
+         */
+        note = await resolveNoteByPublicId(request.params);
 
         if (note) {
           request.noteId = note.id;

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -1,10 +1,10 @@
-import type { FastifyReply, FastifyRequest, preHandlerHookHandler } from 'fastify';
+import type { FastifyRequest, preHandlerHookHandler } from 'fastify';
 import type NoteService from '@domain/service/note.js';
 import notEmpty from '@infrastructure/utils/notEmpty.js';
 import { StatusCodes } from 'http-status-codes';
 import hasProperty from '@infrastructure/utils/hasProperty.js';
 import { getLogger } from '@infrastructure/logging/index.js';
-import type { Note, NoteInternalId, NotePublicId } from '@domain/entities/note';
+import type { Note, NotePublicId } from '@domain/entities/note';
 
 /**
  * Add middleware for resolve Note internal id by public id and add it to request

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -1,0 +1,49 @@
+import type { FastifyRequest, preHandlerHookHandler } from 'fastify';
+import type NoteService from '@domain/service/note.js';
+import notEmpty from '@infrastructure/utils/notEmpty.js';
+import { StatusCodes } from 'http-status-codes';
+import hasProperty from '@infrastructure/utils/hasProperty.js';
+import { getLogger } from '@infrastructure/logging/index.js';
+import type { NotePublicId } from '@domain/entities/note';
+
+/**
+ * Add middleware for resolve Note internal id by public id and add it to request
+ *
+ * @param noteService - note domain service
+ */
+export default function useNoteResolver(noteService: NoteService): {
+  /**
+   * Resolve Note internal id by public id and add it to request
+   *
+   * Use this middleware as "preHandler" hook with a particular route
+   */
+  noteIdResolver: preHandlerHookHandler;
+} {
+  /**
+   * Get logger instance
+   */
+  const logger = getLogger('appServer');
+
+  return {
+    noteIdResolver: async function noteIdResolver(request, reply) {
+      if (hasProperty(request.params, 'notePublicId') && notEmpty(request.params.notePublicId)) {
+        const publicId = request.params.notePublicId as NotePublicId;
+
+        try {
+          const note = await noteService.getNoteByPublicId(publicId);
+
+          request.noteId = note.id;
+        } catch (error) {
+          logger.error('Invalid Note public id: ' + publicId);
+          logger.error(error);
+
+          await reply
+            .code(StatusCodes.UNAUTHORIZED)
+            .send({
+              message: 'Permission denied',
+            });
+        }
+      }
+    },
+  };
+}

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -173,9 +173,10 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
      * @todo Validate request params
      * @todo Check user access right
      */
-    const { id, content } = request.body;
+    const noteId = request.noteId as number;
+    const { content } = request.body;
 
-    const note = await noteService.updateNoteContentByPublicId(id, content);
+    const note = await noteService.updateNoteContentById(noteId, content);
 
     return reply.send({
       updatedAt: note.updatedAt,

--- a/src/repository/note.repository.ts
+++ b/src/repository/note.repository.ts
@@ -61,10 +61,9 @@ export default class NoteRepository {
   }
 
   /**
-   * Get note by public id
+   * Returns note by public id. Null if note does not exist.
    *
    * @param publicId - public id
-   * @returns { Promise<Note | null> } found note
    */
   public async getNoteByPublicId(publicId: NotePublicId): Promise<Note | null> {
     return await this.storage.getNoteByPublicId(publicId);

--- a/src/repository/note.repository.ts
+++ b/src/repository/note.repository.ts
@@ -1,4 +1,4 @@
-import type { Note, NoteCreationAttributes, NotePublicId } from '@domain/entities/note.js';
+import type { Note, NoteCreationAttributes, NoteInternalId, NotePublicId } from '@domain/entities/note.js';
 import type NoteStorage from '@repository/storage/note.storage.js';
 
 /**
@@ -30,14 +30,13 @@ export default class NoteRepository {
   }
 
   /**
-   * Update note content in a store using note public id
+   * Update note content in a store
    *
-   * @param publicId - note public id
+   * @param id - note internal id
    * @param content - new content
-   * @returns Note on success, null on failure
    */
-  public async updateNoteContentByPublicId(publicId: NotePublicId, content: Note['content'] ): Promise<Note | null> {
-    return await this.storage.updateNoteContentByPublicId(publicId, content);
+  public async updateNoteContentById(id: NoteInternalId, content: Note['content'] ): Promise<Note | null> {
+    return await this.storage.updateNoteContentById(id, content);
   }
 
   /**
@@ -46,7 +45,7 @@ export default class NoteRepository {
    * @param id - note id
    * @returns { Promise<Note | null> } found note
    */
-  public async getNoteById(id: Note['id']): Promise<Note | null> {
+  public async getNoteById(id: NoteInternalId): Promise<Note | null> {
     return await this.storage.getNoteById(id);
   }
 

--- a/src/repository/noteSettings.repository.ts
+++ b/src/repository/noteSettings.repository.ts
@@ -1,4 +1,4 @@
-import type { Note, NotePublicId } from '@domain/entities/note.js';
+import type { Note, NoteInternalId, NotePublicId } from '@domain/entities/note.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
 import type NoteSettingsStorage from '@repository/storage/noteSettings.storage.js';
 import type { NoteSettingsCreationAttributes } from '@domain/entities/noteSettings.js';
@@ -25,7 +25,7 @@ export default class NoteSettingsRepository {
    * Gets note settings by id
    *
    * @param id - note id
-   * @returns { Promise<NoteSettings | null> } - found note
+   * @returns found note
    */
   public async getNoteSettingsById(id: NoteSettings['id']): Promise<NoteSettings | null> {
     return await this.storage.getNoteSettingsById(id);
@@ -34,23 +34,10 @@ export default class NoteSettingsRepository {
   /**
    * Get note settings by note id
    *
-   * @param id - note public id
-   * @returns { Promise<NoteSettings | null> } found note settings
-   */
-  public async getNoteSettingsByPublicId(id: NotePublicId): Promise<NoteSettings> {
-    /**
-     * @todo get internal id by public id and resolve note settings by the internal id
-     */
-    return await this.storage.getNoteSettingsByPublicId(id);
-  }
-
-  /**
-   * Get note settings by note id
-   *
    * @param id - note id
-   * @returns { Promise<NoteSettings | null> } found note settings
+   * @returns found note settings
    */
-  public async getNoteSettingsByNoteId(id: Note['id']): Promise<NoteSettings> {
+  public async getNoteSettingsByNoteId(id: NoteInternalId): Promise<NoteSettings> {
     return await this.storage.getNoteSettingsByNoteId(id);
   }
 
@@ -66,11 +53,11 @@ export default class NoteSettingsRepository {
   /**
    * Patch note settings
    *
-   * @param data - note settings new values
    * @param id - note settings id
-   * @returns { Promise<NoteSettings> } patched note settings
+   * @param data - note settings new values
+   * @returns patched note settings
    */
-  public async patchNoteSettingsByPublicId(data: Partial<NoteSettings>, id: NoteSettings['id']): Promise<NoteSettings | null> {
-    return await this.storage.patchNoteSettingsByPublicId(data, id);
+  public async patchNoteSettingsById(id: NoteSettings['id'], data: Partial<NoteSettings>): Promise<NoteSettings | null> {
+    return await this.storage.patchNoteSettingsById(id, data);
   }
 }

--- a/src/repository/noteSettings.repository.ts
+++ b/src/repository/noteSettings.repository.ts
@@ -1,4 +1,4 @@
-import type { Note, NoteInternalId, NotePublicId } from '@domain/entities/note.js';
+import type { NoteInternalId } from '@domain/entities/note.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
 import type NoteSettingsStorage from '@repository/storage/noteSettings.storage.js';
 import type { NoteSettingsCreationAttributes } from '@domain/entities/noteSettings.js';

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -142,18 +142,18 @@ export default class NoteSequelizeStorage {
   }
 
   /**
-   * Update note content by public id
+   * Update note content by id
    *
-   * @param publicId - note public id
+   * @param id - note internal id
    * @param content - new content
    * @returns Note on success, null on failure
    */
-  public async updateNoteContentByPublicId(publicId: NotePublicId, content: Note['content']): Promise<Note | null> {
+  public async updateNoteContentById(id: NoteInternalId, content: Note['content']): Promise<Note | null> {
     const [affectedRowsCount, affectedRows] = await this.model.update({
       content,
     }, {
       where: {
-        publicId,
+        id,
       },
       returning: true,
     });

--- a/src/repository/storage/postgres/orm/sequelize/noteSettings.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteSettings.ts
@@ -1,7 +1,6 @@
 import type { Sequelize, InferAttributes, InferCreationAttributes, CreationOptional, ModelStatic } from 'sequelize';
 import { Model, DataTypes } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
-import type { NotePublicId } from '@domain/entities/note.js';
 import { NoteModel } from '@repository/storage/postgres/orm/sequelize/note.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
 import type { NoteSettingsCreationAttributes } from '@domain/entities/noteSettings.js';
@@ -174,49 +173,6 @@ export default class NoteSettingsSequelizeStorage {
   }
 
   /**
-   * Get note settings
-   *
-   * @param id - note internal id
-   * @returns { Promise<NoteSettings | null> } - note settings
-   *
-   * @deprecated
-   * @todo resolve note setting by internal id
-   */
-  public async getNoteSettingsByPublicId(id: NotePublicId): Promise<NoteSettings> {
-    /**
-     * Check if note model is initialized
-     */
-    if (!this.noteModel) {
-      throw new Error('Note model not initialized');
-    }
-
-    const settings = await this.model.findOne({
-      where: {
-        '$notes.public_id$': id,
-      },
-      include: {
-        model: this.noteModel,
-        as: this.noteModel.tableName,
-        required: true,
-      },
-    });
-
-    if (!settings) {
-      /**
-       * TODO: improve exceptions
-       */
-      throw new Error('Note settings not found');
-    }
-
-    return {
-      id: settings.id,
-      noteId: settings.note_id,
-      customHostname: settings.custom_hostname,
-      enabled: settings.enabled,
-    };
-  }
-
-  /**
    * Insert note settings
    *
    * @param options - note settings options
@@ -245,10 +201,10 @@ export default class NoteSettingsSequelizeStorage {
   /**
    * Update note settings
    *
-   * @param data - note settings new data
    * @param id - note settings id
+   * @param data - note settings new data
    */
-  public async patchNoteSettingsByPublicId(data: Partial<NoteSettings>, id: NoteSettings['id']): Promise<NoteSettings | null> {
+  public async patchNoteSettingsById(id: NoteSettings['id'], data: Partial<NoteSettings>): Promise<NoteSettings | null> {
     const settingsToUpdate = await this.model.findByPk(id);
 
     /**


### PR DESCRIPTION
Implemented a middleware that will convert public id to internal id.

Frontend uses note public id in all requests. Backend accepts note internal id in route handlers. So it will work with Domain services only by internal id.

This middleware does not set by default to all routes, and you need to pass it manually via "preHandler" options