### PR TITLE
chore(decorators): new reply decorators

### DIFF
--- a/src/infrastructure/utils/empty.ts
+++ b/src/infrastructure/utils/empty.ts
@@ -1,0 +1,17 @@
+/**
+ * True if passed variable is not null/undefined/''/{}
+ *
+ * @param v value to check
+ */
+export function notEmpty<T>(v: T | undefined | null | object): v is T {
+  return v !== undefined && v !== null && v !== '' && (typeof v !== 'object' || Object.keys(v).length > 0);
+}
+
+/**
+ * True if passed variable is null/undefined/''/{}
+ *
+ * @param v value to check
+ */
+export function isEmpty(v: unknown): v is null | undefined | '' | Record<string, never> {
+  return !notEmpty(v);
+}

--- a/src/infrastructure/utils/notEmpty.ts
+++ b/src/infrastructure/utils/notEmpty.ts
@@ -1,8 +1,0 @@
-/**
- * Checks for null/undefined/''/{}
- *
- * @param v value to check
- */
-export default function notEmpty<T>(v: T | undefined | null | object): v is T {
-  return v !== undefined && v !== null && v !== '' && (typeof v !== 'object' || Object.keys(v).length > 0);
-}

--- a/src/presentation/http/decorators/forbidden.ts
+++ b/src/presentation/http/decorators/forbidden.ts
@@ -1,0 +1,24 @@
+import { StatusCodes } from 'http-status-codes';
+import type { FastifyReply } from 'fastify';
+
+/**
+ * Custom method for sending 403 error
+ *
+ * Send this error when USER IS AUTHENTICATED, but he doesn't have access to the resource
+ *
+ * @example
+ *
+ *  if (note.creatorId !== userId) {
+ *    return reply.forbidden('You don\'t have access to this note');
+ *  }
+ *
+ * @param message - custom message
+ */
+export default async function forbidden(this: FastifyReply, message = 'Permission denied'): Promise<void> {
+  await this
+    .code(StatusCodes.FORBIDDEN)
+    .type('application/json')
+    .send({
+      message,
+    });
+}

--- a/src/presentation/http/decorators/index.ts
+++ b/src/presentation/http/decorators/index.ts
@@ -1,0 +1,11 @@
+import notFound from './notFound.js';
+import forbidden from './forbidden.js';
+import unauthorized from './unauthorized.js';
+import notAcceptable from './notAcceptable.js';
+
+export {
+  notFound,
+  forbidden,
+  unauthorized,
+  notAcceptable
+};

--- a/src/presentation/http/decorators/notAcceptable.ts
+++ b/src/presentation/http/decorators/notAcceptable.ts
@@ -1,0 +1,24 @@
+import { StatusCodes } from 'http-status-codes';
+import type { FastifyReply } from 'fastify';
+
+/**
+ * "406 Not Acceptable" helper
+ *
+ * This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content following the criteria given by the user agent.
+ *
+ * @example
+ *
+ *  if (note === null) {
+ *    return reply.notAcceptable('Note not found');
+ *  }
+ *
+ * @param message - custom message
+ */
+export default async function notAcceptable(this: FastifyReply, message = 'Resource not found'): Promise<void> {
+  await this
+    .code(StatusCodes.NOT_ACCEPTABLE)
+    .type('application/json')
+    .send({
+      message,
+    });
+}

--- a/src/presentation/http/decorators/notFound.ts
+++ b/src/presentation/http/decorators/notFound.ts
@@ -7,14 +7,13 @@ import type { FastifyReply } from 'fastify';
  * @example
  *
  *  if (note === null) {
- *    return fastify.notFound(reply, 'Note not found');
+ *    return reply.notFound('Note not found');
  *  }
  *
- * @param reply - fastify reply instance
  * @param message - custom message
  */
-export default async function notFound(reply: FastifyReply, message = 'Not found'): Promise<void> {
-  await reply
+export default async function notFound(this: FastifyReply, message = 'Not found'): Promise<void> {
+  await this
     .code(StatusCodes.NOT_FOUND)
     .type('application/json')
     .send({

--- a/src/presentation/http/decorators/unauthorized.ts
+++ b/src/presentation/http/decorators/unauthorized.ts
@@ -1,0 +1,24 @@
+import { StatusCodes } from 'http-status-codes';
+import type { FastifyReply } from 'fastify';
+
+/**
+ * Custom method for sending 401 error
+ *
+ * Send this error when USER IS NOT AUTHENTICATED and he doesn't have access to the resource because of that
+ *
+ * @example
+ *
+ *  if (userId === null) {
+ *    return reply.unauthorized('You must be authenticated to access this resource');
+ *  }
+ *
+ * @param message - custom message
+ */
+export default async function unauthorized(this: FastifyReply, message = 'You must be authenticated to access this resource'): Promise<void> {
+  await this
+    .code(StatusCodes.UNAUTHORIZED)
+    .type('application/json')
+    .send({
+      message,
+    });
+}

--- a/src/presentation/http/fastify.d.ts
+++ b/src/presentation/http/fastify.d.ts
@@ -15,19 +15,7 @@ declare module 'fastify' {
     Logger extends fastify.FastifyBaseLogger = fastify.FastifyBaseLogger,
     TypeProvider extends fastify.FastifyTypeProvider = fastify.FastifyTypeProviderDefault,
   > {
-    /**
-     * Custom method for sending 404 error
-     *
-     * @example
-     *
-     *  if (note === null) {
-     *    return fastify.notFound(reply, 'Note not found');
-     *  }
-     *
-     * @param reply - Fastify reply object
-     * @param message - Optional message to send. If not specified, default message will be sent
-     */
-    notFound: (reply: fastify.FastifyReply, message?: string) => Promise<void>;
+    // put here your custom properties and methods of fastify server instance added by decorators
   }
   /**
    * Type shortcut for fastify server instance
@@ -74,5 +62,68 @@ declare module 'fastify' {
      * This property added by noteSettingsResolver middleware
      */
     noteSettings: NoteSettings | null;
+  }
+
+  /**
+   * Augment FastifyReply to respect properties added by decorators
+   */
+  export interface FastifyReply {
+    /**
+     * Custom method for sending 404 error
+     *
+     * @example
+     *
+     *  if (note === null) {
+     *    return reply.notFound('Note not found');
+     *  }
+     *
+     * @param message - Optional message to send. If not specified, default message will be sent
+     */
+    notFound: (message?: string) => Promise<void>;
+
+    /**
+     * Custom method for sending 403 error
+     *
+     * Send this error when USER IS AUTHENTICATED, but he doesn't have access to the resource
+     *
+     * @example
+     *
+     *  if (note.creatorId !== userId) {
+     *    return reply.forbidden('You don\'t have access to this note');
+     *  }
+     *
+     * @param message - Optional message to send. If not specified, default message will be sent
+     */
+    forbidden: (message?: string) => Promise<void>;
+
+    /**
+     * Custom method for sending 401 error
+     *
+     * Send this error when USER IS NOT AUTHENTICATED and he doesn't have access to the resource because of that
+     *
+     * @example
+     *
+     *  if (userId === null) {
+     *    return reply.unauthorized('You must be authenticated to access this resource');
+     *  }
+     *
+     * @param message - Optional message to send. If not specified, default message will be sent
+     */
+    unauthorized: (message?: string) => Promise<void>;
+
+    /**
+     * Custom method for sending 406 error
+     *
+     * This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content following the criteria given by the user agent.
+     *
+     * @example
+     *
+     *  if (note === null) {
+     *    return reply.notAcceptable('Note not found');
+     *  }
+     *
+     * @param message - Optional message to send. If not specified, default message will be sent
+     */
+    notAcceptable: (message?: string) => Promise<void>;
   }
 }

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -10,7 +10,7 @@ import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUI from '@fastify/swagger-ui';
 import addUserIdResolver from '@presentation/http/middlewares/common/userIdResolver.js';
 import cookie from '@fastify/cookie';
-import NotFoundDecorator from './decorators/notFound.js';
+import { notFound, forbidden, unauthorized, notAcceptable } from './decorators/index.js';
 import NoteRouter from '@presentation/http/router/note.js';
 import OauthRouter from '@presentation/http/router/oauth.js';
 import AuthRouter from '@presentation/http/router/auth.js';
@@ -272,7 +272,10 @@ export default class HttpApi implements Api {
    * Add custom decorators
    */
   private addDecorators(): void {
-    this.server?.decorate('notFound', NotFoundDecorator);
+    this.server?.decorateReply('notFound', notFound);
+    this.server?.decorateReply('forbidden', forbidden);
+    this.server?.decorateReply('unauthorized', unauthorized);
+    this.server?.decorateReply('notAcceptable', notAcceptable);
   }
 
   /**

--- a/src/presentation/http/middlewares/common/userIdResolver.ts
+++ b/src/presentation/http/middlewares/common/userIdResolver.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import type AuthService from '@domain/service/auth.js';
 import type Logger from '@infrastructure/logging/index.js';
-import notEmpty from '@infrastructure/utils/notEmpty.js';
+import { notEmpty } from '@infrastructure/utils/empty.js';
 
 /**
  * Add middleware for resolve userId from Access Token and add it to request

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -1,6 +1,6 @@
 import type { FastifyRequest, preHandlerHookHandler } from 'fastify';
 import type NoteService from '@domain/service/note.js';
-import notEmpty from '@infrastructure/utils/notEmpty.js';
+import { notEmpty } from '@infrastructure/utils/empty.js';
 import { StatusCodes } from 'http-status-codes';
 import hasProperty from '@infrastructure/utils/hasProperty.js';
 import { getLogger } from '@infrastructure/logging/index.js';

--- a/src/presentation/http/policies/authRequired.ts
+++ b/src/presentation/http/policies/authRequired.ts
@@ -1,5 +1,4 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
-import { StatusCodes } from 'http-status-codes';
 
 /**
  * Policy to enforce user to be logged in
@@ -11,10 +10,6 @@ export default async function authRequired(request: FastifyRequest, reply: Fasti
   const { userId } = request;
 
   if (userId === null) {
-    await reply
-      .code(StatusCodes.UNAUTHORIZED)
-      .send({
-        message: 'Permission denied',
-      });
+    return await reply.unauthorized();
   }
 }

--- a/src/presentation/http/policies/index.ts
+++ b/src/presentation/http/policies/index.ts
@@ -1,7 +1,9 @@
 import authRequired from './authRequired.js';
 import notePublicOrUserInTeam from './notePublicOrUserInTeam.js';
+import userInTeam from './userInTeam.js';
 
 export default {
   authRequired,
   notePublicOrUserInTeam,
+  userInTeam,
 };

--- a/src/presentation/http/policies/userInTeam.ts
+++ b/src/presentation/http/policies/userInTeam.ts
@@ -8,7 +8,7 @@ import { isEmpty } from '@infrastructure/utils/empty.js';
  * @param request - Fastify request object
  * @param reply - Fastify reply object
  */
-export default async function notePublicOrUserInTeam(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+export default async function userInTeam(request: FastifyRequest, reply: FastifyReply): Promise<void> {
   const { userId } = request;
 
   if (isEmpty(userId)) {

--- a/src/presentation/http/policies/userInTeam.ts
+++ b/src/presentation/http/policies/userInTeam.ts
@@ -1,8 +1,9 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { isEmpty } from '@infrastructure/utils/empty.js';
 
+
 /**
- * Policy to check does user have permission to access note
+ * Policy to check whether user in a team of note
  *
  * @param request - Fastify request object
  * @param reply - Fastify reply object
@@ -10,21 +11,24 @@ import { isEmpty } from '@infrastructure/utils/empty.js';
 export default async function notePublicOrUserInTeam(request: FastifyRequest, reply: FastifyReply): Promise<void> {
   const { userId } = request;
 
+  if (isEmpty(userId)) {
+    return await reply.unauthorized();
+  };
+
   /**
-   * If note or noteSettings not resolved, we can't check permissions
+   * If note is not resolved, we can't check permissions
    */
-  if (isEmpty(request.note) || isEmpty(request.noteSettings)) {
+  if (isEmpty(request.note)) {
     return await reply.notAcceptable('Note not found');
   };
 
   const { creatorId } = request.note;
-  const { isPublic } = request.noteSettings;
 
   /**
    * If note is public, everyone can access it
    * If note is private, only creator can access it
    */
-  if (isPublic === false && creatorId !== userId) {
+  if (creatorId !== userId) {
     return await reply.forbidden();
   }
 }

--- a/src/presentation/http/policies/userInTeam.ts
+++ b/src/presentation/http/policies/userInTeam.ts
@@ -25,8 +25,7 @@ export default async function userInTeam(request: FastifyRequest, reply: Fastify
   const { creatorId } = request.note;
 
   /**
-   * If note is public, everyone can access it
-   * If note is private, only creator can access it
+   * Check if user can edit note
    */
   if (creatorId !== userId) {
     return await reply.forbidden();

--- a/src/presentation/http/router/auth.ts
+++ b/src/presentation/http/router/auth.ts
@@ -48,11 +48,7 @@ const AuthRouter: FastifyPluginCallback<AuthRouterOptions> = (fastify, opts, don
      * Check if session is valid
      */
     if (!userSession) {
-      return reply
-        .code(StatusCodes.UNAUTHORIZED)
-        .send({
-          message: 'Session is not valid',
-        });
+      return await reply.unauthorized('Session is not valid');
     }
 
     const accessToken = opts.authService.signAccessToken({ id: userSession.userId });

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -40,6 +40,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
    * It should be used in routes that accepts note public id
    */
   const { noteResolver } = useNoteResolver(noteService);
+
   /**
    * Prepare note settings resolver middleware
    * It should be used to use note settings in middlewares
@@ -78,7 +79,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
      * Check if note does not exist
      */
     if (note === null) {
-      return fastify.notFound(reply, 'Note not found');
+      return reply.notFound('Note not found');
     }
 
     return reply.send(note);
@@ -149,15 +150,13 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     config: {
       policy: [
         'authRequired',
+        'userInTeam',
       ],
     },
     preHandler: [
       noteResolver,
     ],
   }, async (request, reply) => {
-    /**
-     * @todo Check user access right
-     */
     const noteId = request.note?.id as number;
     const { content } = request.body;
 
@@ -189,7 +188,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
      * Check if note does not exist
      */
     if (note === null) {
-      return fastify.notFound(reply, 'Note not found');
+      return reply.notFound('Note not found');
     }
 
     return reply.send(note);

--- a/src/presentation/http/router/noteSettings.ts
+++ b/src/presentation/http/router/noteSettings.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type NoteSettingsService from '@domain/service/noteSettings.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
-import notEmpty from '@infrastructure/utils/notEmpty.js';
+import { isEmpty } from '@infrastructure/utils/empty.js';
 import useNoteResolver from '../middlewares/note/useNoteResolver.js';
 import type NoteService from '@domain/service/note.js';
 import type { NotePublicId } from '@domain/entities/note.js';
@@ -64,8 +64,8 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     /**
      * Check if note does not exist
      */
-    if (!notEmpty(noteSettings)) {
-      return fastify.notFound(reply, 'Note settings not found');
+    if (isEmpty(noteSettings)) {
+      return reply.notFound('Note settings not found');
     }
 
     return reply.send(noteSettings);
@@ -107,7 +107,7 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     });
 
     if (updatedNoteSettings === null) {
-      return fastify.notFound(reply, 'Note settings not found');
+      return reply.notFound('Note settings not found');
     }
 
     return reply.send(updatedNoteSettings);

--- a/src/presentation/http/router/oauth.ts
+++ b/src/presentation/http/router/oauth.ts
@@ -46,7 +46,7 @@ const OauthRouter: FastifyPluginCallback<OauthRouterOptions> = (fastify, opts, d
      * Check if user exists
      */
     if (!user) {
-      return fastify.notFound(reply, 'User not found');
+      return reply.notFound('User not found');
     }
 
     /**

--- a/src/presentation/http/router/user.ts
+++ b/src/presentation/http/router/user.ts
@@ -49,7 +49,7 @@ const UserRouter: FastifyPluginCallback<UserRouterOptions> = (fastify, opts, don
     const user = await userService.getUserById(userId);
 
     if (user === null) {
-      return fastify.notFound(reply, 'User not found');
+      return reply.notFound('User not found');
     }
 
     return reply.send(user);

--- a/src/repository/ai.repository.ts
+++ b/src/repository/ai.repository.ts
@@ -1,4 +1,4 @@
-import notEmpty from '@infrastructure/utils/notEmpty.js';
+import { notEmpty } from '@infrastructure/utils/empty.js';
 import type OpenAIApi from './transport/openai-api';
 import type { GetCompletionResponsePayload } from './transport/openai-api/types/GetCompletionResponsePayload';
 


### PR DESCRIPTION
- add `isEmpty` as well as `notEmpty` ---> to get rid of `!notEmpty()`
- added several reply decorators
  - `reply.unauthorized()` — use when there is no user
  - `reply.forbidden()` — use when we have user, but it has no access 
  - `reply.notFound()` — someone requests a resource that we don't have
  - `reply.notAcceptable()` — someone peforms some action on resource that was not found
- added a `userInTeam` policy for checking edit-note permission
- applied a `userInTeam` to `PATCH /node/<id>`