### PR TITLE
Fix multiple run of github action

### DIFF
--- a/.github/workflows/run-build-check.yml
+++ b/.github/workflows/run-build-check.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/run-build-check.yml
+++ b/.github/workflows/run-build-check.yml
@@ -3,14 +3,12 @@ name: Run build check
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - 'v*'
 
   pull_request:
-    types: [opened, edited, synchronize]
-    branches:
-      - '*'
+    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/run-eslint-check.yml
+++ b/.github/workflows/run-eslint-check.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   eslint:

--- a/.github/workflows/run-eslint-check.yml
+++ b/.github/workflows/run-eslint-check.yml
@@ -3,14 +3,12 @@ name: Run ESlint check
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - 'v*'
-      
+
   pull_request:
-    types: [opened, edited, synchronize]
-    branches:
-      - '*'
+    types: [opened, synchronize]
 
 jobs:
   eslint:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   tests:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,14 +3,12 @@ name: Run tests
 on:
   push:
     branches:
-      - '*'
+      - 'main'
     tags:
       - 'v*'
-      
+
   pull_request:
-    types: [opened, edited, synchronize]
-    branches:
-      - '*'
+    types: [opened, synchronize]
 
 jobs:
   tests:


### PR DESCRIPTION
Fixed case, when github actions used to run twice after push to pull request. 
Now the workflows are triggered when pushing only to main branch.
In addition, now workflows won't be triggered when someone edit pull request (for example edit title).