### PR TITLE
feat: notes access rights 

### DIFF
--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -8,17 +8,7 @@ describe('Note API', () => {
   describe('GET note/resolve-hostname/:hostname ', () => {
     test('Returns note with specified hostname', async () => {
       const expectedStatus = 200;
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        url: '/note/resolve-hostname/codex.so',
-      });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
-
-      expect(body).toStrictEqual({
+      const expectedResponse = {
         'note': {
           'id': 1,
           'publicId': 'note_1',
@@ -36,7 +26,16 @@ describe('Note API', () => {
         'accessRights': {
           'canEdit': false,
         },
+      };
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: '/note/resolve-hostname/codex.so',
       });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual(expectedResponse);
     });
 
     test('Returns 404 when note not found', async () => {
@@ -49,9 +48,7 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(expectedStatus);
 
-      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
-
-      expect(body).toStrictEqual({ message: 'Note not found' });
+      expect(response?.json()).toStrictEqual({ message: 'Note not found' });
     });
   });
 
@@ -59,15 +56,7 @@ describe('Note API', () => {
     test('Returns note by public id with 200 status when note is publicly available', async () => {
       const expectedStatus = 200;
       const correctID = 'Pq1T9vc23Q';
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        url: `/note/${correctID}`,
-      });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      expect(response?.json()).toStrictEqual({
+      const expectedResponse = {
         'note': {
           'id': 2,
           'publicId': 'Pq1T9vc23Q',
@@ -79,11 +68,33 @@ describe('Note API', () => {
         'accessRights': {
           'canEdit': false,
         },
+      };
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note/${correctID}`,
       });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual(expectedResponse);
     });
 
     test('Returns note by public id with 200 status when access is disabled, but user is creator', async () => {
       const expectedStatus = 200;
+      const expectedResponse = {
+        'note': {
+          'id': 3,
+          'publicId': '73NdxFZ4k7',
+          'creatorId': 1,
+          'content': null,
+          'createdAt': '2023-10-16T13:49:19.000Z',
+          'updatedAt': '2023-10-16T13:49:19.000Z',
+        },
+        'accessRights': {
+          'canEdit': true,
+        },
+      };
       const userId = 1;
       const accessToken = global.auth(userId);
 
@@ -103,19 +114,7 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(expectedStatus);
 
-      expect(response?.json()).toStrictEqual({
-        'note': {
-          'id': 3,
-          'publicId': '73NdxFZ4k7',
-          'creatorId': 1,
-          'content': null,
-          'createdAt': '2023-10-16T13:49:19.000Z',
-          'updatedAt': '2023-10-16T13:49:19.000Z',
-        },
-        'accessRights': {
-          'canEdit': true,
-        },
-      });
+      expect(response?.json()).toStrictEqual(expectedResponse);
     });
 
     test('Returns 403 when the note is not public, the user is not authorized', async () => {

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -175,6 +175,58 @@ describe('Note API', () => {
       expect(response?.json()).toStrictEqual({ message: 'Note not found' });
     });
 
+    test('Returns public note by public id with false canEdit flag, when user is not authorized', async () => {
+      const expectedStatus = 200;
+      const publicId = 'Pq1T9vc23Q';
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note/${publicId}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+    });
+
+    test('Returns public note by public id with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
+      const expectedStatus = 200;
+      const publicId = 'Pq1T9vc23Q';
+      const userId = 4;
+      const accessToken = global.auth(userId);
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note/${publicId}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+    });
+
+    test('Returns public note by public id with false canEdit flag, when user is authorized and is the creator of the note', async () => {
+      const expectedStatus = 200;
+      const publicId = 'Pq1T9vc23Q';
+      const userId = 1;
+      const accessToken = global.auth(userId);
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note/${publicId}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json().accessRights).toStrictEqual({ canEdit: true });
+    });
+
     test.each([
       { id: 'mVz3iHuez',
         expectedMessage: 'params/notePublicId must NOT have fewer than 10 characters' },

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -174,58 +174,6 @@ describe('Note API', () => {
       expect(response?.json()).toStrictEqual({ message: 'Note not found' });
     });
 
-    test('Returns public note by public id with status 200 and with false canEdit flag, when user is not authorized', async () => {
-      const expectedStatus = 200;
-      const publicId = 'Pq1T9vc23Q';
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        url: `/note/${publicId}`,
-      });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
-    });
-
-    test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
-      const expectedStatus = 200;
-      const publicId = 'Pq1T9vc23Q';
-      const userId = 4;
-      const accessToken = global.auth(userId);
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        headers: {
-          authorization: `Bearer ${accessToken}`,
-        },
-        url: `/note/${publicId}`,
-      });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
-    });
-
-    test('Returns public note by public id with status 200 and with true canEdit flag, when user is authorized and is the creator of the note', async () => {
-      const expectedStatus = 200;
-      const publicId = 'Pq1T9vc23Q';
-      const userId = 1;
-      const accessToken = global.auth(userId);
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        headers: {
-          authorization: `Bearer ${accessToken}`,
-        },
-        url: `/note/${publicId}`,
-      });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      expect(response?.json().accessRights).toStrictEqual({ canEdit: true });
-    });
-
     test.each([
       { id: 'mVz3iHuez',
         expectedMessage: 'params/notePublicId must NOT have fewer than 10 characters' },
@@ -250,5 +198,59 @@ describe('Note API', () => {
     });
 
     test.todo('API should not return internal id and "publicId".  It should return only "id" which is public id.');
+  });
+});
+
+describe('Access rights', () => {
+  test('Returns public note by public id with status 200 and with false canEdit flag, when user is not authorized', async () => {
+    const expectedStatus = 200;
+    const publicId = 'Pq1T9vc23Q';
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      url: `/note/${publicId}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+  });
+
+  test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
+    const expectedStatus = 200;
+    const publicId = 'Pq1T9vc23Q';
+    const userId = 4;
+    const accessToken = global.auth(userId);
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+      },
+      url: `/note/${publicId}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+  });
+
+  test('Returns public note by public id with status 200 and with true canEdit flag, when user is authorized and is the creator of the note', async () => {
+    const expectedStatus = 200;
+    const publicId = 'Pq1T9vc23Q';
+    const userId = 1;
+    const accessToken = global.auth(userId);
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+      },
+      url: `/note/${publicId}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json().accessRights).toStrictEqual({ canEdit: true });
   });
 });

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -207,7 +207,7 @@ describe('Note API', () => {
       expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
     });
 
-    test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized and is the creator of the note', async () => {
+    test('Returns public note by public id with status 200 and with true canEdit flag, when user is authorized and is the creator of the note', async () => {
       const expectedStatus = 200;
       const publicId = 'Pq1T9vc23Q';
       const userId = 1;

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -10,17 +10,22 @@ describe('Note API', () => {
       const expectedStatus = 200;
       /* eslint-disable @typescript-eslint/naming-convention */
       const expectedNote = {
-        'id': 1,
-        'publicId': 'note_1',
-        'creatorId': 1,
-        'content': null,
-        'createdAt': '2023-10-16T13:49:19.000Z',
-        'updatedAt': '2023-10-16T13:49:19.000Z',
-        'noteSettings':  {
-          'customHostname': 'codex.so',
-          'isPublic': true,
+        'note': {
           'id': 1,
-          'noteId': 1,
+          'publicId': 'note_1',
+          'creatorId': 1,
+          'content': null,
+          'createdAt': '2023-10-16T13:49:19.000Z',
+          'updatedAt': '2023-10-16T13:49:19.000Z',
+          'noteSettings':  {
+            'customHostname': 'codex.so',
+            'isPublic': true,
+            'id': 1,
+            'noteId': 1,
+          },
+        },
+        'accessRights': {
+          'canEdit': false,
         },
       };
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -59,12 +64,17 @@ describe('Note API', () => {
       const correctID = 'Pq1T9vc23Q';
 
       const expectedNote = {
-        'id': 2,
-        'publicId': 'Pq1T9vc23Q',
-        'creatorId': 1,
-        'content': null,
-        'createdAt': '2023-10-16T13:49:19.000Z',
-        'updatedAt': '2023-10-16T13:49:19.000Z',
+        'note': {
+          'id': 2,
+          'publicId': 'Pq1T9vc23Q',
+          'creatorId': 1,
+          'content': null,
+          'createdAt': '2023-10-16T13:49:19.000Z',
+          'updatedAt': '2023-10-16T13:49:19.000Z',
+        },
+        'accessRights': {
+          'canEdit': false,
+        },
       };
 
       const response = await global.api?.fakeRequest({
@@ -83,12 +93,17 @@ describe('Note API', () => {
       const accessToken = global.auth(userId);
 
       const expectedNote = {
-        'id': 3,
-        'publicId': '73NdxFZ4k7',
-        'creatorId': 1,
-        'content': null,
-        'createdAt': '2023-10-16T13:49:19.000Z',
-        'updatedAt': '2023-10-16T13:49:19.000Z',
+        'note': {
+          'id': 3,
+          'publicId': '73NdxFZ4k7',
+          'creatorId': 1,
+          'content': null,
+          'createdAt': '2023-10-16T13:49:19.000Z',
+          'updatedAt': '2023-10-16T13:49:19.000Z',
+        },
+        'accessRights': {
+          'canEdit': true,
+        },
       };
 
       const privateUserNote = notes.find(newNote => {

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -202,7 +202,7 @@ describe('Note API', () => {
 });
 
 describe('Access rights', () => {
-  test('Returns public note by public id with status 200 and with false canEdit flag, when user is not authorized', async () => {
+  test('Returns canEdit=false flag, when user is not authorized', async () => {
     const expectedStatus = 200;
     const publicId = 'Pq1T9vc23Q';
 
@@ -216,7 +216,7 @@ describe('Access rights', () => {
     expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
   });
 
-  test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
+  test('Returns canEdit=false when user is authorized, but is not the creator', async () => {
     const expectedStatus = 200;
     const publicId = 'Pq1T9vc23Q';
     const userId = 4;
@@ -235,7 +235,7 @@ describe('Access rights', () => {
     expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
   });
 
-  test('Returns public note by public id with status 200 and with true canEdit flag, when user is authorized and is the creator of the note', async () => {
+  test('Returns canEdit=true, when user is authorized and is the creator of the note', async () => {
     const expectedStatus = 200;
     const publicId = 'Pq1T9vc23Q';
     const userId = 1;

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -197,60 +197,60 @@ describe('Note API', () => {
       expect(response?.json().message).toStrictEqual(expectedMessage);
     });
 
+    describe('Access rights', () => {
+      test('Returns canEdit=false flag, when user is not authorized', async () => {
+        const expectedStatus = 200;
+        const publicId = 'Pq1T9vc23Q';
+
+        const response = await global.api?.fakeRequest({
+          method: 'GET',
+          url: `/note/${publicId}`,
+        });
+
+        expect(response?.statusCode).toBe(expectedStatus);
+
+        expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+      });
+
+      test('Returns canEdit=false when user is authorized, but is not the creator', async () => {
+        const expectedStatus = 200;
+        const publicId = 'Pq1T9vc23Q';
+        const userId = 4;
+        const accessToken = global.auth(userId);
+
+        const response = await global.api?.fakeRequest({
+          method: 'GET',
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+          },
+          url: `/note/${publicId}`,
+        });
+
+        expect(response?.statusCode).toBe(expectedStatus);
+
+        expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
+      });
+
+      test('Returns canEdit=true, when user is authorized and is the creator of the note', async () => {
+        const expectedStatus = 200;
+        const publicId = 'Pq1T9vc23Q';
+        const userId = 1;
+        const accessToken = global.auth(userId);
+
+        const response = await global.api?.fakeRequest({
+          method: 'GET',
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+          },
+          url: `/note/${publicId}`,
+        });
+
+        expect(response?.statusCode).toBe(expectedStatus);
+
+        expect(response?.json().accessRights).toStrictEqual({ canEdit: true });
+      });
+    });
+
     test.todo('API should not return internal id and "publicId".  It should return only "id" which is public id.');
-  });
-});
-
-describe('Access rights', () => {
-  test('Returns canEdit=false flag, when user is not authorized', async () => {
-    const expectedStatus = 200;
-    const publicId = 'Pq1T9vc23Q';
-
-    const response = await global.api?.fakeRequest({
-      method: 'GET',
-      url: `/note/${publicId}`,
-    });
-
-    expect(response?.statusCode).toBe(expectedStatus);
-
-    expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
-  });
-
-  test('Returns canEdit=false when user is authorized, but is not the creator', async () => {
-    const expectedStatus = 200;
-    const publicId = 'Pq1T9vc23Q';
-    const userId = 4;
-    const accessToken = global.auth(userId);
-
-    const response = await global.api?.fakeRequest({
-      method: 'GET',
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-      },
-      url: `/note/${publicId}`,
-    });
-
-    expect(response?.statusCode).toBe(expectedStatus);
-
-    expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
-  });
-
-  test('Returns canEdit=true, when user is authorized and is the creator of the note', async () => {
-    const expectedStatus = 200;
-    const publicId = 'Pq1T9vc23Q';
-    const userId = 1;
-    const accessToken = global.auth(userId);
-
-    const response = await global.api?.fakeRequest({
-      method: 'GET',
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-      },
-      url: `/note/${publicId}`,
-    });
-
-    expect(response?.statusCode).toBe(expectedStatus);
-
-    expect(response?.json().accessRights).toStrictEqual({ canEdit: true });
   });
 });

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -175,7 +175,7 @@ describe('Note API', () => {
       expect(response?.json()).toStrictEqual({ message: 'Note not found' });
     });
 
-    test('Returns public note by public id with false canEdit flag, when user is not authorized', async () => {
+    test('Returns public note by public id with status 200 and with false canEdit flag, when user is not authorized', async () => {
       const expectedStatus = 200;
       const publicId = 'Pq1T9vc23Q';
 
@@ -189,7 +189,7 @@ describe('Note API', () => {
       expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
     });
 
-    test('Returns public note by public id with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
+    test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized, but is not the creator of the note', async () => {
       const expectedStatus = 200;
       const publicId = 'Pq1T9vc23Q';
       const userId = 4;
@@ -208,7 +208,7 @@ describe('Note API', () => {
       expect(response?.json().accessRights).toStrictEqual({ canEdit: false });
     });
 
-    test('Returns public note by public id with false canEdit flag, when user is authorized and is the creator of the note', async () => {
+    test('Returns public note by public id with status 200 and with false canEdit flag, when user is authorized and is the creator of the note', async () => {
       const expectedStatus = 200;
       const publicId = 'Pq1T9vc23Q';
       const userId = 1;

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -8,8 +8,17 @@ describe('Note API', () => {
   describe('GET note/resolve-hostname/:hostname ', () => {
     test('Returns note with specified hostname', async () => {
       const expectedStatus = 200;
-      /* eslint-disable @typescript-eslint/naming-convention */
-      const expectedNote = {
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: '/note/resolve-hostname/codex.so',
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
+
+      expect(body).toStrictEqual({
         'note': {
           'id': 1,
           'publicId': 'note_1',
@@ -27,19 +36,7 @@ describe('Note API', () => {
         'accessRights': {
           'canEdit': false,
         },
-      };
-      /* eslint-enable @typescript-eslint/naming-convention */
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        url: '/note/resolve-hostname/codex.so',
       });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
-
-      expect(body).toStrictEqual(expectedNote);
     });
 
     test('Returns 404 when note not found', async () => {
@@ -63,7 +60,14 @@ describe('Note API', () => {
       const expectedStatus = 200;
       const correctID = 'Pq1T9vc23Q';
 
-      const expectedNote = {
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note/${correctID}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual({
         'note': {
           'id': 2,
           'publicId': 'Pq1T9vc23Q',
@@ -75,36 +79,13 @@ describe('Note API', () => {
         'accessRights': {
           'canEdit': false,
         },
-      };
-
-      const response = await global.api?.fakeRequest({
-        method: 'GET',
-        url: `/note/${correctID}`,
       });
-
-      expect(response?.statusCode).toBe(expectedStatus);
-
-      expect(response?.json()).toStrictEqual(expectedNote);
     });
 
     test('Returns note by public id with 200 status when access is disabled, but user is creator', async () => {
       const expectedStatus = 200;
       const userId = 1;
       const accessToken = global.auth(userId);
-
-      const expectedNote = {
-        'note': {
-          'id': 3,
-          'publicId': '73NdxFZ4k7',
-          'creatorId': 1,
-          'content': null,
-          'createdAt': '2023-10-16T13:49:19.000Z',
-          'updatedAt': '2023-10-16T13:49:19.000Z',
-        },
-        'accessRights': {
-          'canEdit': true,
-        },
-      };
 
       const privateUserNote = notes.find(newNote => {
         const settings = noteSettings.find(ns => ns.note_id === newNote.id);
@@ -122,7 +103,19 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(expectedStatus);
 
-      expect(response?.json()).toStrictEqual(expectedNote);
+      expect(response?.json()).toStrictEqual({
+        'note': {
+          'id': 3,
+          'publicId': '73NdxFZ4k7',
+          'creatorId': 1,
+          'content': null,
+          'createdAt': '2023-10-16T13:49:19.000Z',
+          'updatedAt': '2023-10-16T13:49:19.000Z',
+        },
+        'accessRights': {
+          'canEdit': true,
+        },
+      });
     });
 
     test('Returns 403 when the note is not public, the user is not authorized', async () => {

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -54,7 +54,10 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     Params: {
       notePublicId: NotePublicId;
     },
-    Reply: Note | ErrorResponse,
+    Reply: {
+      note : Note
+      accessRights: { canEdit: boolean },
+    } | ErrorResponse,
   }>('/:notePublicId', {
     config: {
       policy: [
@@ -82,7 +85,15 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       return reply.notFound('Note not found');
     }
 
-    return reply.send(note);
+    /**
+     * Check if current user is creator of the note
+     */
+    const canEdit = note.creatorId === request.userId;
+
+    return reply.send({
+      note: note,
+      accessRights: { canEdit: canEdit },
+    });
   });
 
   /**
@@ -215,7 +226,10 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
        */
       hostname: string;
     },
-    Reply: Note
+    Reply: {
+      note : Note
+      accessRights: { canEdit: boolean },
+    } | ErrorResponse,
   }>('/resolve-hostname/:hostname', async (request, reply) => {
     const params = request.params;
 
@@ -228,7 +242,15 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       return reply.notFound('Note not found');
     }
 
-    return reply.send(note);
+    /**
+     * Check if current user is creator of the note
+     */
+    const canEdit = note.creatorId === request.userId;
+
+    return reply.send({
+      note: note,
+      accessRights: { canEdit: canEdit },
+    });
   });
 
   done();


### PR DESCRIPTION
Added information about access rights to reply in get note by id method and in get note by custom hostname method.
For now, it only checks, if current user is creator of the note. 
Also, tests in note.test were changed because of new reply format.