### PR TITLE
chore: global.db.query()

### DIFF
--- a/src/tests/utils/setup.ts
+++ b/src/tests/utils/setup.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 
-
 import { insertData } from './insert-data';
 import { initORM, init as initRepositories } from '@repository/index.js';
 import { init as initDomainServices } from '@domain/index.js';
@@ -35,7 +34,6 @@ declare global {
    * @returns accessToken for authorization
    */
   function auth(userId: number) : string;
-
 
   /* eslint-disable-next-line no-var */
   var db: {


### PR DESCRIPTION
Added `global.db.query()` helper that allows to execute sql statements in test DB. 
Such function will be helpful for [another pull request](https://github.com/codex-team/notes.api/pull/100), where we want to insert tomorrow date as expiration date for the session