### PR TITLE
feat: note settings request validation for note settings

### DIFF
--- a/src/presentation/api.interface.ts
+++ b/src/presentation/api.interface.ts
@@ -35,7 +35,7 @@ export interface RequestParams {
   /**
    * Request method
    */
-  method: 'POST' | 'GET' | 'PUT' | 'DELETE',
+  method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'PATCH',
 
   /**
    * Request urk

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -106,4 +106,83 @@ describe('NoteSettings API', () => {
 
     expect(response?.json()).toStrictEqual({ message: 'Permission denied' });
   });
+
+  describe('GET /note-settings/:notePublicId/team ', () => {
+    test('Returns team by public id with 200 status, user is creator of the note', async () => {
+      const expectedStatus = 200;
+      const userId = 2;
+      const accessToken = global.auth(userId);
+
+      const userNote = notes.find(newNote => {
+        return newNote.creator_id === userId;
+      });
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note-settings/${userNote!.public_id}/team`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+    });
+
+    test('Returns status 401 when the user is not authorized', async () => {
+      const expectedStatus = 401;
+      const correctID = 'Pq1T9vc23Q';
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${correctID}/team`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual({ message: 'You must be authenticated to access this resource' });
+    });
+
+    test('Returns status 406 when the public id does not exist', async () => {
+      const expectedStatus = 406;
+      const nonexistentId = 'ishvm5qH84';
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${nonexistentId}/team`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual({ message: 'Note not found' });
+    });
+
+    test.each([
+      { id: 'mVz3iHuez',
+        expectedMessage: 'params/notePublicId must NOT have fewer than 10 characters' },
+
+      { id: 'cR8eqF1mFf0',
+        expectedMessage: 'params/notePublicId must NOT have more than 10 characters' },
+
+      { id: '+=*&*5%&&^&-',
+        expectedMessage: '\'/note-settings/+=*&*5%&&^&-/team\' is not a valid url component' },
+    ])
+    ('Returns 400 when public id of the note settings has incorrect characters and length', async ({ id, expectedMessage }) => {
+      const expectedStatus = 400;
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${id}/team`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json().message).toStrictEqual(expectedMessage);
+    });
+
+    test.todo('We should to check team value in tests');
+
+    test.todo('Returns team by public id with 200 status, user is not creator of the note, but a member of the team');
+
+    test.todo('Returns 403 when user authorized, but not member of the team');
+  });
 });

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from 'vitest';
 
+import notes from '@tests/test-data/notes.json';
+import noteSettings from '@tests/test-data/notes-settings.json';
+
 describe('NoteSettings API', () => {
   describe('GET /note-settings/:notePublicId ', () => {
     test('Returns note settings by public id with 200 status', async () => {
@@ -38,21 +41,69 @@ describe('NoteSettings API', () => {
     expect(response?.json()).toStrictEqual({ message: 'Note not found' });
   });
 
-  test('Returns 400 when an id has invalid characters', async () => {
+  test.each([
+    { id: 'mVz3iHuez',
+      expectedMessage: 'params/notePublicId must NOT have fewer than 10 characters' },
+
+    { id: 'cR8eqF1mFf0',
+      expectedMessage: 'params/notePublicId must NOT have more than 10 characters' },
+
+    { id: '+=*&*5%&&^&-',
+      expectedMessage: '\'/note-settings/+=*&*5%&&^&-\' is not a valid url component' },
+  ])
+  ('Returns 400 when public id of the note settings has incorrect characters and length', async ({ id, expectedMessage }) => {
     const expectedStatus = 400;
-    const invalidId = '+=*&*5%&&^&-';
 
     const response = await global.api?.fakeRequest({
       method: 'GET',
-      url: `/note-settings/${invalidId}`,
+      url: `/note-settings/${id}`,
     });
 
     expect(response?.statusCode).toBe(expectedStatus);
 
-    expect(response?.json().message).toStrictEqual('\'/note-settings/+=*&*5%&&^&-\' is not a valid url component');
+    expect(response?.json().message).toStrictEqual(expectedMessage);
   });
 
-  test.todo('Returns 400 when an id has incorrect length');
+  test('Returns 403 when the note is not public, the user is not authorized', async () => {
+    const expectedStatus = 403;
 
-  test.todo('Returns 403 when public access is disabled, user is not creator of the note');
+    const notPublicNote = notes.find(newNote => {
+      const settings = noteSettings.find(ns => ns.note_id === newNote.id);
+
+      return settings!.is_public === false;
+    });
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      url: `/note-settings/${notPublicNote!.public_id}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json()).toStrictEqual({ message: 'Permission denied' });
+  });
+
+  test('Returns 403 when public access is disabled, user is not creator of the note', async () => {
+    const expectedStatus = 403;
+    const userId = 2;
+    const accessToken = global.auth(userId);
+
+    const notPublicNote = notes.find(newNote => {
+      const settings = noteSettings.find(ns => ns.note_id === newNote.id);
+
+      return settings!.is_public === false && newNote.creator_id != userId;
+    });
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+      },
+      url: `/note-settings/${notPublicNote!.public_id}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json()).toStrictEqual({ message: 'Permission denied' });
+  });
 });

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -6,7 +6,7 @@ describe('NoteSettings API', () => {
       const expectedStatus = 200;
       const existedNotePublicId = 'Pq1T9vc23Q';
 
-      const expectedNote = {
+      const expectedNoteSettings = {
         'customHostname': 'codex.so',
         'isPublic': true,
         'id': 2,
@@ -22,7 +22,39 @@ describe('NoteSettings API', () => {
 
       const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
 
-      expect(body).toStrictEqual(expectedNote);
+      expect(body).toStrictEqual(expectedNoteSettings);
     });
   });
+
+  test('Returns 406 when the id  does not exist', async () => {
+    const expectedStatus = 406;
+    const nonexistentId = 'ishvm5qH84';
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      url: `/note-settings/${nonexistentId}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json()).toStrictEqual({ message: 'Note not found' });
+  });
+
+  test('Returns 400 when an id has invalid characters', async () => {
+    const expectedStatus = 400;
+    const invalidId = '+=*&*5%&&^&-';
+
+    const response = await global.api?.fakeRequest({
+      method: 'GET',
+      url: `/note-settings/${invalidId}`,
+    });
+
+    expect(response?.statusCode).toBe(expectedStatus);
+
+    expect(response?.json().message).toStrictEqual('\'/note-settings/+=*&*5%&&^&-\' is not a valid url component');
+  });
+
+  test.todo('Returns 400 when an id has incorrect length');
+
+  test.todo('Returns 403 when public access is disabled, user is not creator of the note');
 });

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -7,6 +7,10 @@ describe('NoteSettings API', () => {
   describe('GET /note-settings/:notePublicId ', () => {
     test('Returns note settings by public id with 200 status', async () => {
       const expectedStatus = 200;
+
+      /**
+       * @todo сделать поиск заметки по ид чтобы тест был визуально понятнее, убрать existingNotePublicId
+       */
       const existingNotePublicId = 'Pq1T9vc23Q';
 
       const expectedNoteSettings = {
@@ -184,5 +188,99 @@ describe('NoteSettings API', () => {
     test.todo('Returns team by public id with 200 status, user is not creator of the note, but a member of the team');
 
     test.todo('Returns 403 when user authorized, but not member of the team');
+  });
+
+  describe('PATCH /note-settings/:notePublicId ', () => {
+    test('Update note settings by public id with 200 status, user is creator of the note', async () => {
+      const expectedStatus = 200;
+      const userId = 2;
+      const accessToken = global.auth(userId);
+
+      const userNote = notes.find(newNote => {
+        return newNote.creator_id === userId;
+      });
+
+      const updatedNoteSettings = {
+        'id': 53,
+        'noteId': 53,
+        'customHostname': 'codex.so',
+        'isPublic': false,
+      };
+
+      const response = await global.api?.fakeRequest({
+        method: 'PATCH',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note-settings/${userNote!.public_id}`,
+        body: {
+          'isPublic': false,
+        },
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual(updatedNoteSettings);
+    });
+
+    test('Returns status 401 when the user is not authorized', async () => {
+      const expectedStatus = 401;
+      const correctID = 'Pq1T9vc23Q';
+
+      const response = await global.api?.fakeRequest({
+        method: 'PATCH',
+        url: `/note-settings/${correctID}`,
+        body: {
+          'isPublic': false,
+        },
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual({ message: 'You must be authenticated to access this resource' });
+    });
+
+    test('Returns status 406 when the public id does not exist', async () => {
+      const expectedStatus = 406;
+      const nonexistentId = 'ishvm5qH84';
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${nonexistentId}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json()).toStrictEqual({ message: 'Note not found' });
+    });
+
+    test.each([
+      { id: 'mVz3iHuez',
+        expectedMessage: 'params/notePublicId must NOT have fewer than 10 characters' },
+
+      { id: 'cR8eqF1mFf0',
+        expectedMessage: 'params/notePublicId must NOT have more than 10 characters' },
+
+      { id: '+=*&*5%&&^&-',
+        expectedMessage: '\'/note-settings/+=*&*5%&&^&-\' is not a valid url component' },
+    ])
+    ('Returns 400 when public id of the note settings has incorrect characters and length', async ({ id, expectedMessage }) => {
+      const expectedStatus = 400;
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${id}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      expect(response?.json().message).toStrictEqual(expectedMessage);
+    });
+
+    test.todo('Return 200 when user in team and have Member Role = write');
+
+    test.todo('Return 403 when user in team and have Member Role = read');
+
+    test.todo('Return 403 when user authorized, but not member of the team');
   });
 });

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -7,10 +7,6 @@ describe('NoteSettings API', () => {
   describe('GET /note-settings/:notePublicId ', () => {
     test('Returns note settings by public id with 200 status', async () => {
       const expectedStatus = 200;
-
-      /**
-       * @todo сделать поиск заметки по ид чтобы тест был визуально понятнее, убрать existingNotePublicId
-       */
       const existingNotePublicId = 'Pq1T9vc23Q';
 
       const expectedNoteSettings = {

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest';
+
+describe('NoteSettings API', () => {
+  describe('GET note-settings/:notePublicId ', () => {
+    test('Returns note settings by public id with 200 status', async () => {
+      const expectedStatus = 200;
+      const existedNotePublicId = 'Pq1T9vc23Q';
+
+      const expectedNote = {
+        'customHostname': 'codex.so',
+        'isPublic': true,
+        'id': 2,
+        'noteId': 2,
+      };
+
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: `/note-settings/${existedNotePublicId}`,
+      });
+
+      expect(response?.statusCode).toBe(expectedStatus);
+
+      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
+
+      expect(body).toStrictEqual(expectedNote);
+    });
+  });
+});

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from 'vitest';
 
 describe('NoteSettings API', () => {
-  describe('GET note-settings/:notePublicId ', () => {
+  describe('GET /note-settings/:notePublicId ', () => {
     test('Returns note settings by public id with 200 status', async () => {
       const expectedStatus = 200;
-      const existedNotePublicId = 'Pq1T9vc23Q';
+      const existingNotePublicId = 'Pq1T9vc23Q';
 
       const expectedNoteSettings = {
         'customHostname': 'codex.so',
@@ -15,18 +15,16 @@ describe('NoteSettings API', () => {
 
       const response = await global.api?.fakeRequest({
         method: 'GET',
-        url: `/note-settings/${existedNotePublicId}`,
+        url: `/note-settings/${existingNotePublicId}`,
       });
 
       expect(response?.statusCode).toBe(expectedStatus);
 
-      const body = response?.body !== undefined ? JSON.parse(response?.body) : {};
-
-      expect(body).toStrictEqual(expectedNoteSettings);
+      expect(response?.json()).toStrictEqual(expectedNoteSettings);
     });
   });
 
-  test('Returns 406 when the id  does not exist', async () => {
+  test('Returns 406 when note settings with specified note public id do not exist', async () => {
     const expectedStatus = 406;
     const nonexistentId = 'ishvm5qH84';
 

--- a/src/presentation/http/router/noteSettings.ts
+++ b/src/presentation/http/router/noteSettings.ts
@@ -4,6 +4,7 @@ import type NoteSettings from '@domain/entities/noteSettings.js';
 import { isEmpty } from '@infrastructure/utils/empty.js';
 import useNoteResolver from '../middlewares/note/useNoteResolver.js';
 import type NoteService from '@domain/service/note.js';
+import useNoteSettingsResolver from '../middlewares/noteSettings/useNoteSettingsResolver.js';
 import type { NotePublicId } from '@domain/entities/note.js';
 import type { Team } from '@domain/entities/team.js';
 
@@ -43,6 +44,12 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
   const { noteResolver } = useNoteResolver(noteService);
 
   /**
+   * Prepare note settings resolver middleware
+   * It should be used to use note settings in middlewares
+   */
+  const { noteSettingsResolver } = useNoteSettingsResolver(noteSettingsService);
+
+  /**
    * Returns Note settings by note id. Note public id is passed in route params, and it converted to internal id via middleware
    */
   fastify.get<{
@@ -51,13 +58,23 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     },
     Reply: NoteSettings
   }>('/:notePublicId', {
+    config: {
+      policy: [
+        'notePublicOrUserInTeam',
+      ],
+    },
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+    },
     preHandler: [
       noteResolver,
+      noteSettingsResolver,
     ],
   }, async (request, reply) => {
-    /**
-     * TODO: Validate request params
-     */
     const noteId = request.note?.id as number;
 
     const noteSettings = await noteSettingsService.getNoteSettingsByNoteId(noteId);

--- a/src/presentation/http/router/noteSettings.ts
+++ b/src/presentation/http/router/noteSettings.ts
@@ -104,6 +104,13 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
         'authRequired',
       ],
     },
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+    },
     preHandler: [
       noteResolver,
     ],
@@ -132,6 +139,7 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
   });
 
   /**
+   * Get team by note id
    * TODO add policy for this route (check if user is collaborator)
    */
   fastify.get<{
@@ -140,6 +148,13 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     },
     Reply: Team,
   }>('/:notePublicId/team', {
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+    },
     preHandler: [
       noteResolver,
     ],

--- a/src/presentation/http/router/noteSettings.ts
+++ b/src/presentation/http/router/noteSettings.ts
@@ -102,6 +102,7 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     config: {
       policy: [
         'authRequired',
+        'userInTeam',
       ],
     },
     schema: {
@@ -148,6 +149,12 @@ const NoteSettingsRouter: FastifyPluginCallback<NoteSettingsRouterOptions> = (fa
     },
     Reply: Team,
   }>('/:notePublicId/team', {
+    config: {
+      policy: [
+        'authRequired',
+        'userInTeam',
+      ],
+    },
     schema: {
       params: {
         notePublicId: {

--- a/src/tests/test-data/notes-settings.json
+++ b/src/tests/test-data/notes-settings.json
@@ -18,5 +18,12 @@
     "note_id": 3,
     "custom_hostname": "codex.so",
     "is_public": false
+  },
+
+  {
+    "id": 53,
+    "note_id": 53,
+    "custom_hostname": "codex.so",
+    "is_public": true
   }
 ]

--- a/src/tests/test-data/notes.json
+++ b/src/tests/test-data/notes.json
@@ -415,5 +415,13 @@
     "content": [],
     "created_at": "2023-10-16T13:49:2.000Z",
     "updated_at": "2023-10-16T13:49:2.000Z"
+  },
+    { 
+    "id": 53,
+    "public_id": "f43NU75weU",
+    "creator_id": 2,
+    "content": [],
+    "created_at": "2023-10-16T13:49:19.000Z",
+    "updated_at": "2023-10-16T13:49:19.000Z"
   }
 ]

--- a/src/tests/test-data/users.json
+++ b/src/tests/test-data/users.json
@@ -6,6 +6,12 @@
     "created_at": "2023-10-16T13:49:19.000Z"
   },
   {
+    "id": 2,
+    "email": "elizachi@gmail.com",
+    "name": "Елизавета",
+    "created_at": "2023-10-22 19:19:40.892+03"
+  }, 
+  {
     "id": 4,
     "email": "Egoramurin@gmail.com",
     "name": "Егор Амурин",


### PR DESCRIPTION
Added a schema to all methods to validate the id value. Also added some testcases and todos.

**GET note settings**:
- 200 status if note settings publicly available
- 400 status when public id has invalid characters
- 403 status public access is disabled
- 406 status when public id not exist

**GET team by public id** and **PATCH note settings by public id**:
- 200 status if note settings publicly available
- 400 status when public id has invalid characters
- 401 status when user is not authorized
- 406 status when public id not exist