### PR TITLE
Oauth Invalid State 500 error

### DIFF
--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -140,7 +140,7 @@ export default class HttpApi implements Api {
           securitySchemes: {
             oAuthGoogle: {
               type: 'oauth2',
-              description: 'Provied authorization uses OAuth 2 with Google',
+              description: 'Provided authorization uses OAuth 2 with Google',
               flows: {
                 authorizationCode: {
                   authorizationUrl: 'https://api.notex.so/oauth/google/login',

--- a/src/presentation/http/router/noteList.test.ts
+++ b/src/presentation/http/router/noteList.test.ts
@@ -1,9 +1,5 @@
-<<<<<<< HEAD
-import userSessions from '@tests/test-data/user-sessions.json';
-=======
 // import type AuthSession from '@domain/entities/authSession';
-import userSessions from '@tests/test-data/userSessions.json';
->>>>>>> 023a509cd58ac661142c392596df8e9a10c65342
+import userSessions from '@tests/test-data/user-sessions.json';
 import { describe, test, expect, beforeAll } from 'vitest';
 
 /**
@@ -11,24 +7,14 @@ import { describe, test, expect, beforeAll } from 'vitest';
  */
 let accessToken = '';
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 023a509cd58ac661142c392596df8e9a10c65342
 describe('NoteList API', () => {
   beforeAll(() => {
     /**
      * userId for authorization
      */
-<<<<<<< HEAD
-    const userId = userSessions[0]['user_id'];
-
-    accessToken = global.auth(userId);
-=======
     const id = userSessions[0]['user_id'];
 
     accessToken = global.auth(id);
->>>>>>> 023a509cd58ac661142c392596df8e9a10c65342
   });
 
   describe('GET /notes?page', () => {

--- a/src/presentation/http/router/noteList.test.ts
+++ b/src/presentation/http/router/noteList.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect, beforeAll } from 'vitest';
 
 
 /**
- * Access token that will be used for Auhorization header
+ * Access token that will be used for Authorization header
  */
 let accessToken = '';
 
@@ -79,7 +79,7 @@ describe('NoteList API', () => {
     });
 
     test('Returns 400 when page < 0', async () => {
-      const expextedStatus = 400;
+      const expectedStatus = 400;
       const pageNumber = 0;
 
 
@@ -91,11 +91,11 @@ describe('NoteList API', () => {
         url: `/notes?page=${pageNumber}`,
       });
 
-      expect(response?.statusCode).toBe(expextedStatus);
+      expect(response?.statusCode).toBe(expectedStatus);
     });
 
     test('Returns 400 when page is too large (maximum page numbrer is 30 by default)', async () => {
-      const expextedStatus = 400;
+      const expectedStatus = 400;
       const pageNumber = 31;
 
       const response = await global.api?.fakeRequest({
@@ -106,7 +106,7 @@ describe('NoteList API', () => {
         url: `/notes?page=${pageNumber}`,
       });
 
-      expect(response?.statusCode).toBe(expextedStatus);
+      expect(response?.statusCode).toBe(expectedStatus);
     });
   });
 });

--- a/src/presentation/http/router/noteList.test.ts
+++ b/src/presentation/http/router/noteList.test.ts
@@ -94,7 +94,7 @@ describe('NoteList API', () => {
       expect(response?.statusCode).toBe(expectedStatus);
     });
 
-    test('Returns 400 when page is too large (maximum page numbrer is 30 by default)', async () => {
+    test('Returns 400 when page is too large (maximum page number is 30 by default)', async () => {
       const expectedStatus = 400;
       const pageNumber = 31;
 

--- a/src/presentation/http/router/oauth.test.ts
+++ b/src/presentation/http/router/oauth.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+
+describe('Oauth API', () => {
+  describe('GET /google/callback', () => {
+    test('Returns a login user', async () => {
+      const response = await global.api?.fakeRequest({
+        method: 'GET',
+        url: '/oauth/google/callback',
+      });
+
+      console.log(response?.statusCode);
+
+      expect(response?.statusCode).toBe(200);
+    });
+  });
+});

--- a/src/repository/transport/openai-api/index.ts
+++ b/src/repository/transport/openai-api/index.ts
@@ -7,7 +7,7 @@ import type { ApiResponse } from '../google-api/types/ApiResponse';
  */
 export default class OpenAIApi extends Transport {
   /**
-   * Constructs OpenAI api tranport instance
+   * Constructs OpenAI api transport instance
    *
    * @param baseUrl - Base url for the api
    */

--- a/src/repository/transport/openai-api/index.ts
+++ b/src/repository/transport/openai-api/index.ts
@@ -7,7 +7,7 @@ import type { ApiResponse } from '../google-api/types/ApiResponse';
  */
 export default class OpenAIApi extends Transport {
   /**
-   * Constructs OpenAI api transport instance
+   * Constructs OpenAI api transwport instance
    *
    * @param baseUrl - Base url for the api
    */

--- a/src/tests/utils/setup.ts
+++ b/src/tests/utils/setup.ts
@@ -30,28 +30,10 @@ declare global {
    * Globally exposed method for creating accessToken using id
    * Is accessed as 'global.server' in tests
    *
-<<<<<<< HEAD
-   * @param userId - id of the user that will be considered the author of the request
-   * @returns accessToken for authorization
-   */
-  function auth(userId: number): string;
-
-  /* eslint-disable-next-line no-var */
-  var db: {
-    /**
-     * Executes specified sql query in test DB.
-     * Might be used in tests to perform some specific database operations
-     *
-     * @param sql - string containing sql to execute in test DB
-     */
-    query: (sql: string) => Promise<unknown>;
-  };
-=======
    * @param id - id for making accessToken
    * @returns accessToken for authorization
    */
   function auth(id: number) : string;
->>>>>>> 023a509cd58ac661142c392596df8e9a10c65342
 }
 
 /**
@@ -77,20 +59,8 @@ beforeAll(async () => {
   await insertData(orm);
 
   global.api = api;
-<<<<<<< HEAD
-
-  global.auth = (userId: number) => {
-    return domainServices.authService.signAccessToken({ id : userId });
-  };
-
-  global.db = {
-    query: async (sqlString: string) => {
-      return await orm.connection.query(sqlString);
-    },
-=======
   global.auth = (id: number) => {
     return domainServices.authService.signAccessToken({ id : id });
->>>>>>> 023a509cd58ac661142c392596df8e9a10c65342
   };
 }, TIMEOUT);
 

--- a/src/tests/utils/setup.ts
+++ b/src/tests/utils/setup.ts
@@ -41,7 +41,7 @@ declare global {
      * Executes specified sql query in test DB.
      * Might be used in tests to perform some specific database operations
      *
-     * @param sql - string containing sql to executein test DB
+     * @param sql - string containing sql to execute in test DB
      */
     query: (sql: string) => Promise<unknown>;
   };


### PR DESCRIPTION
Fastify Google Oauth returns an Invalid state for Google Oauth and a status code of 500 during a test. 


Note: This has been tested locally and it works fine 