### PR TITLE
Feat: Add migration scripts to deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,14 @@ FROM node:20-alpine AS runner
 WORKDIR /usr/app
 
 COPY --from=builder /app/dist ./dist
-COPY package.json yarn.lock .yarnrc.yml ./
+COPY package.json yarn.lock .yarnrc.yml tsconfig.json ./
 COPY .yarn/releases ./.yarn/releases
 RUN yarn install
 COPY ./app-config.yaml .
 COPY ./migrations ./migrations
 COPY ./init.sh .
+COPY ./src/infrastructure/config/index.ts ./src/infrastructure/config/
+COPY ./src/infrastructure/logging/index.ts ./src/infrastructure/logging/
 
 USER node
 ENV NODE_ENV="production"

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 set -e
-node dist/repository/storage/postgres/migrations/index.js -c app-config.yaml
 node dist/index.js

--- a/migrations/scripts/index.ts
+++ b/migrations/scripts/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import config from './../../../../infrastructure/config/index.js';
+import config from '@infrastructure/config/index.js';
 import { runTenantMigrations } from './migrate.js';
 
 /**

--- a/migrations/scripts/migrate.ts
+++ b/migrations/scripts/migrate.ts
@@ -1,6 +1,6 @@
 import pg, { type ClientConfig } from 'pg';
 import { migrate } from 'postgres-migrations';
-import logger from './../../../../infrastructure/logging/index.js';
+import logger from '@infrastructure/logging/index.js';
 
 
 /**

--- a/src/tests/utils/setup.ts
+++ b/src/tests/utils/setup.ts
@@ -6,7 +6,7 @@ import { insertData } from './insert-data';
 import { initORM, init as initRepositories } from '@repository/index.js';
 import { init as initDomainServices } from '@domain/index.js';
 import config from '@infrastructure/config/index.js';
-import { runTenantMigrations } from '@repository/storage/postgres/migrations/migrate';
+import { runTenantMigrations } from '../../../migrations/scripts/migrate.js';
 import API from '@presentation/index.js';
 
 import { beforeAll, afterAll } from 'vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "src/**/*.ts",
     "vitest.config.js",
     ".eslintrc.cjs",
-    "fastify.d.ts", "migrations/scripts/index.ts", "migrations/scripts/migrate.ts",
+    "fastify.d.ts",
   ],
   "ts-node": {
     // Tell ts-node CLI to install the --loader automatically

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "src/**/*.ts",
     "vitest.config.js",
     ".eslintrc.cjs",
-    "fastify.d.ts",
+    "fastify.d.ts", "migrations/scripts/index.ts", "migrations/scripts/migrate.ts",
   ],
   "ts-node": {
     // Tell ts-node CLI to install the --loader automatically

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "vitest.config.js",
     ".eslintrc.cjs",
     "fastify.d.ts",
+    "migrations/scripts/*.ts",
   ],
   "ts-node": {
     // Tell ts-node CLI to install the --loader automatically


### PR DESCRIPTION
2 migration scripts were moved to migration folder from /src/.
And Dockerfile was modified to COPY these scripts as well as configs and files they depend on.

Accepting any ideas / suggestions.