### PR TITLE
Update migrations

### DIFF
--- a/migrations/tenant/0010-note-relations@add-note-relations-table.sql
+++ b/migrations/tenant/0010-note-relations@add-note-relations-table.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS public.note_relations (
 --
 -- Name: note_relations relation_id; Type: PK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.note_relations DROP CONSTRAINT IF EXISTS relation_id_pkey;
+ALTER TABLE public.note_relations DROP CONSTRAINT IF EXISTS relation_id;
 ALTER TABLE public.note_relations 
     ADD CONSTRAINT relation_id PRIMARY KEY (id);
 

--- a/migrations/tenant/0010-note-relations@add-note-relations-table.sql
+++ b/migrations/tenant/0010-note-relations@add-note-relations-table.sql
@@ -11,9 +11,9 @@ CREATE TABLE IF NOT EXISTS public.note_relations (
 --
 -- Name: note_relations relation_id; Type: PK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.note_relations DROP CONSTRAINT IF EXISTS relation_id;
+ALTER TABLE public.note_relations DROP CONSTRAINT IF EXISTS note_relations_pkey;
 ALTER TABLE public.note_relations 
-    ADD CONSTRAINT relation_id PRIMARY KEY (id);
+    ADD CONSTRAINT note_relations_pkey PRIMARY KEY (id);
 
 --
 -- Name: note_relations child_note_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex

--- a/migrations/tenant/0011-teams@add-teams-table.sql
+++ b/migrations/tenant/0011-teams@add-teams-table.sql
@@ -12,9 +12,9 @@ CREATE TABLE IF NOT EXISTS public.teams (
 --
 -- Name: teams team_id_pkey; Type: PK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS team_id_pkey;
+ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS teams_pkey;
 ALTER TABLE public.teams 
-    ADD CONSTRAINT team_id_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT teams_pkey PRIMARY KEY (id);
 
 --
 -- Name: teams user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex

--- a/migrations/tenant/0011-teams@add-teams-table.sql
+++ b/migrations/tenant/0011-teams@add-teams-table.sql
@@ -10,11 +10,11 @@ CREATE TABLE IF NOT EXISTS public.teams (
 );
 
 --
--- Name: teams relation_id_pkey; Type: PK CONSTRAINT; Schema: public; Owner: codex
+-- Name: teams team_id_pkey; Type: PK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS relation_id_pkey;
+ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS team_id_pkey;
 ALTER TABLE public.teams 
-    ADD CONSTRAINT relation_id_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT team_id_pkey PRIMARY KEY (id);
 
 --
 -- Name: teams user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex

--- a/migrations/tenant/0012-note-settings@rename-notes-settings-to-note-settings.sql
+++ b/migrations/tenant/0012-note-settings@rename-notes-settings-to-note-settings.sql
@@ -4,8 +4,16 @@ BEGIN
     FROM information_schema.tables
     WHERE table_name= 'notes_settings')
   THEN
-    DROP TABLE IF EXISTS public.note_settings;
-    ALTER TABLE public.notes_settings 
-      RENAME TO note_settings;
+    -- if note_settings table is already created, then we just drop empty notes_settings
+    -- if there is no note_settings table, then we rename notes_settings -> note_settings 
+    IF EXISTS(SELECT *
+      FROM information_schema.tables
+      WHERE table_name= 'note_settings')
+    THEN
+      DROP TABLE public.notes_settings CASCADE;
+    ELSE
+      ALTER TABLE public.notes_settings 
+        RENAME TO note_settings;
+    END IF;
   END IF;
 END $$;

--- a/migrations/tenant/0014-note-teams@rename-teams-to-note-teams.sql
+++ b/migrations/tenant/0014-note-teams@rename-teams-to-note-teams.sql
@@ -4,8 +4,18 @@ BEGIN
     FROM information_schema.tables
     WHERE table_name= 'teams')
   THEN
-    DROP TABLE IF EXISTS public.note_teams;
-    ALTER TABLE public.teams
-      RENAME TO note_teams;
+    -- if note_teams table already exists, then we drop teams table
+    -- if there is no note_teams table, then we rename teams pkey and rename table teams -> note_teams
+    IF EXISTS(SELECT * 
+      FROM information_schema.tables
+      WHERE table_name= 'note_teams')
+    THEN
+      DROP TABLE public.teams CASCADE;
+    ELSE
+      ALTER TABLE public.teams
+        RENAME CONSTRAINT teams_pkey TO note_teams_pkey;
+      ALTER TABLE public.teams
+        RENAME TO note_teams;
+    END IF;
   END IF;
 END $$;

--- a/migrations/tenant/0016-note-teams@add-auto-increment-id.sql
+++ b/migrations/tenant/0016-note-teams@add-auto-increment-id.sql
@@ -6,8 +6,6 @@ CREATE SEQUENCE IF NOT EXISTS public.note_teams_id_seq
     NO MAXVALUE
     CACHE 1;
 
--- ALTER TABLE public.note_teams_id_seq OWNER TO codex;
-
 ALTER SEQUENCE public.note_teams_id_seq OWNED BY public.note_teams.id;
 
 -- Make identifier default value incrementing

--- a/migrations/tenant/0016-note-teams@add-auto-increment-id.sql
+++ b/migrations/tenant/0016-note-teams@add-auto-increment-id.sql
@@ -6,7 +6,7 @@ CREATE SEQUENCE IF NOT EXISTS public.note_teams_id_seq
     NO MAXVALUE
     CACHE 1;
 
-ALTER TABLE public.note_teams_id_seq OWNER TO codex;
+-- ALTER TABLE public.note_teams_id_seq OWNER TO codex;
 
 ALTER SEQUENCE public.note_teams_id_seq OWNED BY public.note_teams.id;
 

--- a/src/repository/storage/postgres/migrations/index.ts
+++ b/src/repository/storage/postgres/migrations/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import config from '@infrastructure/config/index.js';
+import config from './../../../../infrastructure/config/index.js';
 import { runTenantMigrations } from './migrate.js';
 
 /**

--- a/src/repository/storage/postgres/migrations/migrate.ts
+++ b/src/repository/storage/postgres/migrations/migrate.ts
@@ -1,6 +1,6 @@
 import pg, { type ClientConfig } from 'pg';
 import { migrate } from 'postgres-migrations';
-import logger from '@infrastructure/logging/index.js';
+import logger from './../../../../infrastructure/logging/index.js';
 
 
 /**


### PR DESCRIPTION
Various fixes in migrations in order to make it possible to run them without errors. 

Note: remove `migrations` table before run