### PR TITLE
fixed 500 error in auth tests

### DIFF
--- a/src/presentation/http/router/auth.test.ts
+++ b/src/presentation/http/router/auth.test.ts
@@ -24,7 +24,7 @@ describe('Auth API', () => {
       /**
        * Insert session data to the DB with tomorrow expiration date
        */
-      await global.db.query(`INSERT INTO public.user_sessions (id, "user_id", "refresh_token", "refresh_token_expires_at") VALUES (9999, 1, '${refreshToken}', CURRENT_DATE + INTERVAL '1 day')`);
+      await global.db.query(`INSERT INTO public.user_sessions ("user_id", "refresh_token", "refresh_token_expires_at") VALUES (1, '${refreshToken}', CURRENT_DATE + INTERVAL '1 day')`);
 
       const response = await global.api?.fakeRequest({
         method: 'POST',
@@ -56,7 +56,7 @@ describe('Auth API', () => {
         body:{ token: outdatedToken },
       });
 
-      expect (response?.statusCode).toBe(401);
+      expect(response?.statusCode).toBe(401);
 
       const body = await response?.json();
 

--- a/src/tests/test-data/user-sessions.json
+++ b/src/tests/test-data/user-sessions.json
@@ -1,12 +1,10 @@
 [
   {
-    "id": 2,
     "user_id": 4,
     "refresh_token": "F5tTF24K9Q",
     "refresh_token_expires_at": "2023-11-09 11:23:54+02"
   },
   {
-    "id": 3,
     "user_id": 1,
     "refresh_token": "IqrTkSKmel",
     "refresh_token_expires_at": "2025-11-21 19:19:40.911+03"

--- a/src/tests/utils/insert-data.ts
+++ b/src/tests/utils/insert-data.ts
@@ -35,7 +35,7 @@ async function insertNoteTeams(db: SequelizeOrm): Promise<void> {
  */
 async function insertUserSessions(db: SequelizeOrm): Promise<void> {
   for (const userSession of userSessions) {
-    await db.connection.query(`INSERT INTO public.user_sessions (id, "user_id", "refresh_token", "refresh_token_expires_at") VALUES (${userSession.id}, ${userSession.user_id}, '${userSession.refresh_token}', '${userSession.refresh_token_expires_at}')`);
+    await db.connection.query(`INSERT INTO public.user_sessions ("user_id", "refresh_token", "refresh_token_expires_at") VALUES (${userSession.user_id}, '${userSession.refresh_token}', '${userSession.refresh_token_expires_at}')`);
   }
 }
 /**


### PR DESCRIPTION
- 500 error raised if we started indexing of `user-sessions` test data with 1 because we used `global.db.query` method in test (id was 9999 and autoincrement sequence made minvalue 1 + 1, so we can't insert data with id 1).
- decided to insert `user-session` without id since it is not used anywhere, so that the id is generated using auto-increment