### PR TITLE
Add a commit and a user who triggered the checks to the checks message

### DIFF
--- a/.github/workflows/send-test-results.yml
+++ b/.github/workflows/send-test-results.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get actions results
         run: |
           echo 'ACTIONS_RESULTS<<0x0a' >> $GITHUB_ENV
-          echo -e "👏 ${{ github.triggering_actor }}:\n${{ env.REF }}\n" >> $GITHUB_ENV
+          echo -e "👏 Checks triggered by ${{ github.triggering_actor }} in\n${{ env.REF }}\n" >> $GITHUB_ENV
           curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"\
            "$API_URL" | jq -r '.workflow_runs[] | select(((.head_sha=="${{ env.COMMIT_SHA }}") and (.id != ${{ github.run_id }}))
             and ((.conclusion == "success") or (.conclusion == "failure"))) | "\(.conclusion) [\(.name)](\(.html_url))" |

--- a/.github/workflows/send-test-results.yml
+++ b/.github/workflows/send-test-results.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get actions results
         run: |
           echo 'ACTIONS_RESULTS<<0x0a' >> $GITHUB_ENV
-          echo -e "👏 Checks triggered by ${{ github.triggering_actor }} in\n${{ env.REF }}\n" >> $GITHUB_ENV
+          echo -e "👏 ${{ github.triggering_actor }}:\n${{ env.REF }}\n" >> $GITHUB_ENV
           curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"\
            "$API_URL" | jq -r '.workflow_runs[] | select(((.head_sha=="${{ env.COMMIT_SHA }}") and (.id != ${{ github.run_id }}))
             and ((.conclusion == "success") or (.conclusion == "failure"))) | "\(.conclusion) [\(.name)](\(.html_url))" |

--- a/.github/workflows/send-test-results.yml
+++ b/.github/workflows/send-test-results.yml
@@ -18,13 +18,17 @@ jobs:
     env:
       API_URL: "https://api.github.com/repos/${{ github.repository }}/actions/runs"
     steps:
-      - name: Set commit_sha to pull request head sha
+      - name: Set commit_sha to pull request head sha and ref to pull request
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        run: |
+          echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          echo "REF=[${{ github.event.pull_request.title }}](${{ github.event.pull_request.url }})" >> $GITHUB_ENV
 
-      - name: Set commit_sha to pushed commit sha
+      - name: Set commit_sha to pushed commit sha and ref to branch name
         if: ${{ github.event_name == 'push' }}
-        run: echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+        run: |
+          echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+          echo "REF=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Wait for other checks to succeed
         uses: lewagon/wait-on-check-action@v1.3.1
@@ -37,11 +41,9 @@ jobs:
 
         # Find results of the actions with the same SHA as this action via github api and set them to env variable
       - name: Get actions results
-        env:
-          TRIGGERED_COMMIT_URL: https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}
         run: |
           echo 'ACTIONS_RESULTS<<0x0a' >> $GITHUB_ENV
-          echo -e "👏 Checks triggered by ${{ github.triggering_actor }}'s [commit]($TRIGGERED_COMMIT_URL)\n" >> $GITHUB_ENV
+          echo -e "👏 ${{ github.triggering_actor }}:\n${{ env.REF }}\n" >> $GITHUB_ENV
           curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"\
            "$API_URL" | jq -r '.workflow_runs[] | select(((.head_sha=="${{ env.COMMIT_SHA }}") and (.id != ${{ github.run_id }}))
             and ((.conclusion == "success") or (.conclusion == "failure"))) | "\(.conclusion) [\(.name)](\(.html_url))" |

--- a/.github/workflows/send-test-results.yml
+++ b/.github/workflows/send-test-results.yml
@@ -22,13 +22,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          echo "REF=[${{ github.event.pull_request.title }}](${{ github.event.pull_request.url }})" >> $GITHUB_ENV
+          echo "REF=[${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" >> $GITHUB_ENV
 
       - name: Set commit_sha to pushed commit sha and ref to branch name
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
-          echo "REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "REF=[${{ github.ref_name }}](https://github.com/${{ github.repository }}/tree/${{ github.ref }})" >> $GITHUB_ENV
 
       - name: Wait for other checks to succeed
         uses: lewagon/wait-on-check-action@v1.3.1

--- a/.github/workflows/send-test-results.yml
+++ b/.github/workflows/send-test-results.yml
@@ -37,24 +37,16 @@ jobs:
 
         # Find results of the actions with the same SHA as this action via github api and set them to env variable
       - name: Get actions results
+        env:
+          TRIGGERED_COMMIT_URL: https://github.com/${{ github.repository }}/commit/${{ env.COMMIT_SHA }}
         run: |
           echo 'ACTIONS_RESULTS<<0x0a' >> $GITHUB_ENV
+          echo -e "👏 Checks triggered by ${{ github.triggering_actor }}'s [commit]($TRIGGERED_COMMIT_URL)\n" >> $GITHUB_ENV
           curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}"\
            "$API_URL" | jq -r '.workflow_runs[] | select(((.head_sha=="${{ env.COMMIT_SHA }}") and (.id != ${{ github.run_id }}))
             and ((.conclusion == "success") or (.conclusion == "failure"))) | "\(.conclusion) [\(.name)](\(.html_url))" |
              gsub("success"; "✅") | gsub("failure"; "❌")' >> $GITHUB_ENV
           echo '0x0a' >> $GITHUB_ENV
-
-        # Stop if all checks were skipped/cancelled
-      - name: Stop this workflow if none of the results have conclusion "success" or "failure"
-        if: ${{ env.ACTIONS_RESULTS == '' }}
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          ${{ env.API_URL }}/${{ github.run_id }}/cancel
 
       - name: Send a message
         uses: codex-team/action-codexbot-notify@v1


### PR DESCRIPTION
Now the message will look like this, which is a lot nicer imo:

👏 Checks triggered by GoldenJaden in
[Add a commit and a user who triggered the checks to the checks message](https://github.com/codex-team/notes.api/pull/211)

✅ [Build check](https://github.com/codex-team/notes.api/actions/runs/8123223136)
✅ [ESLint](https://github.com/codex-team/notes.api/actions/runs/8123223135)
✅ [API tests](https://github.com/codex-team/notes.api/actions/runs/8123223133)

Also, I deleted an overhead step about checking if all of the actions were cancelled / etc, because in real world it would _almost certainly_ never happen and it's just slowing down the pipeline