### PR TITLE
feat: Support for test coverage reports

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,8 @@ jobs:
         run: yarn coverage
         
       - name: Get an appropriate name for an artifact
-        run: echo "ARTIFACT_NAME='coverage-${{ matrix.branch }}' | tr -d ':<>|*?\r\n\/\\'" >> $GITHUB_ENV
+        if: ${{ matrix.branch != 'main' }}
+        run: echo "ARTIFACT_NAME=coverage-${{ matrix.branch }}" | tr -d ':<>|*?\r\n\/\\' >> $GITHUB_ENV
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
@@ -82,6 +83,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Get a name of the artifact
+        if: ${{ github.head_ref != 'main' }}
         run: echo ARTIFACT_NAME="coverage-${{ matrix.branch }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
 
       - name: Download coverage artifacts for the current branch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,8 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     strategy:
+      # If set to true, Github will cancel all other jobs if one of the jobs fails
+      fail-fast: false
       matrix:
         branch:
           - ${{ github.head_ref }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,6 +81,11 @@ jobs:
     needs: tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
       - name: Get a name of the artifact
         run: echo ARTIFACT_NAME="coverage-${{ github.head_ref }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    permissions:
+      # Required to checkout the code
+      contents: read
     strategy:
       # If set to true, Github will cancel all other jobs if one of the jobs fails
       fail-fast: false
@@ -20,12 +23,6 @@ jobs:
         branch:
           - ${{ github.head_ref }}
           - "main"
-    
-    permissions:
-      # Required to checkout the code
-      contents: read
-      # Required to put a comment into the pull-request
-      pull-requests: write
 
     services:
       postgres:
@@ -82,6 +79,11 @@ jobs:
   report-coverage:
     needs: tests
     runs-on: ubuntu-22.04
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,7 +49,7 @@ jobs:
           time: '20s'
 
       - name: Set permissions for database directory
-        run: sudo chmod -R 755 database
+        run: sudo chmod -R u+wX database
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,12 +65,15 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: npx vitest --coverage.enabled true
+        run: yarn coverage
+        
+      - name: Get an appropriate name for an artifact
+        run: echo "ARTIFACT_NAME='coverage-${{ matrix.branch }}' | tr -d ':<>|*?\r\n\/\\'" >> $GITHUB_ENV
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.branch }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: coverage
       
 
@@ -78,10 +81,13 @@ jobs:
     needs: tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Get a name of the artifact
+        run: echo ARTIFACT_NAME="coverage-${{ matrix.branch }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
+
       - name: Download coverage artifacts for the current branch
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ github.head_ref }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: coverage
           
       - name: Download coverage artifacts for the main branch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,6 @@ jobs:
         run: yarn coverage
         
       - name: Get an appropriate name for an artifact
-        if: ${{ matrix.branch != 'main' }}
         run: echo "ARTIFACT_NAME=coverage-${{ matrix.branch }}" | tr -d ':<>|*?\r\n\/\\' >> $GITHUB_ENV
 
       - name: Upload coverage
@@ -83,7 +82,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Get a name of the artifact
-        if: ${{ github.head_ref != 'main' }}
         run: echo ARTIFACT_NAME="coverage-${{ matrix.branch }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
 
       - name: Download coverage artifacts for the current branch

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,7 +49,7 @@ jobs:
           time: '20s'
 
       - name: Set permissions for database directory
-        run: sudo chmod -R 777 database
+        run: sudo chmod -R 755 database
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Get a name of the artifact
-        run: echo ARTIFACT_NAME="coverage-${{ matrix.branch }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
+        run: echo ARTIFACT_NAME="coverage-${{ github.head_ref }}" | tr -d ":<>|*?\r\n\/\\" >> $GITHUB_ENV
 
       - name: Download coverage artifacts for the current branch
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           time: '20s'
 
-      - name: Set permissions for database directory
-        run: sudo chmod -R u+wX database
+      - name: Make runner the owner of database folder
+        run: sudo chown $USER database
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,12 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     
+    permissions:
+      # Required to checkout the code
+      contents: read
+      # Required to put a comment into the pull-request
+      pull-requests: write
+
     services:
       postgres:
         image: postgres
@@ -52,5 +58,10 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: yarn test
+        run: yarn coverage
+
+      - name: Report coverage
+        # if: always() is set to generate the report even if tests are failing
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@v2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: yarn coverage
+        run: npx vitest --coverage.enabled true
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,7 +49,7 @@ jobs:
           time: '20s'
 
       - name: Make runner the owner of database folder
-        run: sudo chown $USER database
+        run: sudo chown -R $USER database
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        branch:
+          - ${{ github.head_ref }}
+          - "main"
     
     permissions:
       # Required to checkout the code
@@ -47,7 +52,9 @@ jobs:
         run: sudo chmod -R 777 database
 
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -60,8 +67,32 @@ jobs:
       - name: Run tests
         run: yarn coverage
 
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.branch }}
+          path: coverage
+      
+
+  report-coverage:
+    needs: tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download coverage artifacts for the current branch
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ github.head_ref }}
+          path: coverage
+          
+      - name: Download coverage artifacts for the main branch
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-main
+          path: coverage-main
+
       - name: Report coverage
         # if: always() is set to generate the report even if tests are failing
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2
-
+        with:
+          json-summary-compare-path: coverage-main/coverage-summary.json

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "test:dev": "vitest",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit -p ."
   },
   "author": "",
@@ -22,6 +23,7 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^20.2.3",
     "@types/pg": "^8.10.2",
+    "@vitest/coverage-v8": "^1.3.1",
     "eslint": "^8.41.0",
     "eslint-config-codex": "^1.8.3",
     "eslint-plugin-vitest": "^0.3.1",
@@ -31,7 +33,7 @@
     "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.6",
     "typescript": "^5.0.4",
-    "vitest": "^0.34.5"
+    "vitest": "^1.3.1"
   },
   "dependencies": {
     "@codex-team/config-loader": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^20.2.3",
     "@types/pg": "^8.10.2",
-    "@vitest/coverage-v8": "^1.3.1",
+    "@vitest/coverage-v8": "^0.34.5",
     "eslint": "^8.41.0",
     "eslint-config-codex": "^1.8.3",
     "eslint-plugin-vitest": "^0.3.1",
@@ -33,7 +33,7 @@
     "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.6",
     "typescript": "^5.0.4",
-    "vitest": "^1.3.1"
+    "vitest": "^0.34.5"
   },
   "dependencies": {
     "@codex-team/config-loader": "^1.0.0",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     setupFiles: [ 'src/tests/utils/setup.ts' ],
+    coverage: {
+      reporter: ['text', 'json-summary', 'json'],
+      reportOnFailure: true,
+    },
   },
   resolve: {
     alias: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
         branches: 80,
         functions: 80,
         statements: 80
+      },
     },
   },
   resolve: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,6 +8,11 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json-summary', 'json'],
       reportOnFailure: true,
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80
     },
   },
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ampproject/remapping@npm:^2.2.1":
+  version: 2.3.0
+  resolution: "@ampproject/remapping@npm:2.3.0"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: d3ad7b89d973df059c4e8e6d7c972cbeb1bb2f18f002a3bd04ae0707da214cb06cc06929b65aa2313b9347463df2914772298bae8b1d7973f246bb3f2ab3e8f0
+  languageName: node
+  linkType: hard
+
 "@balena/dockerignore@npm:^1.0.2":
   version: 1.0.2
   resolution: "@balena/dockerignore@npm:1.0.2"
   checksum: 0d39f8fbcfd1a983a44bced54508471ab81aaaa40e2c62b46a9f97eac9d6b265790799f16919216db486331dedaacdde6ecbd6b7abe285d39bc50de111991699
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
   languageName: node
   linkType: hard
 
@@ -477,12 +494,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@istanbuljs/schema@npm:^0.1.2":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 5282759d961d61350f33d9118d16bcaed914ebf8061a52f4fa474b2cb08720c9c81d165e13b82f2e5a8a212cc5af482f0c6fc1ac27b9e067e5394c9a6ed186c9
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
   dependencies:
     "@sinclair/typebox": ^0.27.8
   checksum: 910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
+  languageName: node
+  linkType: hard
+
+"@jridgewell/gen-mapping@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
+  dependencies:
+    "@jridgewell/set-array": ^1.2.1
+    "@jridgewell/sourcemap-codec": ^1.4.10
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: ff7a1764ebd76a5e129c8890aa3e2f46045109dabde62b0b6c6a250152227647178ff2069ea234753a690d8f3c4ac8b5e7b267bbee272bffb7f3b0a370ab6e52
   languageName: node
   linkType: hard
 
@@ -493,7 +528,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.15":
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 83b85f72c59d1c080b4cbec0fef84528963a1b5db34e4370fa4bd1e3ff64a0d80e0cee7369d11d73c704e0286fb2865b530acac7a871088fbe92b5edf1000870
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@jridgewell/set-array@npm:1.2.1"
+  checksum: 832e513a85a588f8ed4f27d1279420d8547743cc37fcad5a5a76fc74bb895b013dfe614d0eed9cb860048e6546b798f8f2652020b4b2ba0561b05caa8c654b10
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
@@ -507,6 +556,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.24":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: 9d3c40d225e139987b50c48988f8717a54a8c994d8a948ee42e1412e08988761d0754d7d10b803061cc3aebf35f92a5dbbab493bd0e1a9ef9e89a2130e83ba34
   languageName: node
   linkType: hard
 
@@ -743,6 +802,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-lib-coverage@npm:^2.0.1":
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.12":
   version: 7.0.14
   resolution: "@types/json-schema@npm:7.0.14"
@@ -945,6 +1011,27 @@ __metadata:
     "@typescript-eslint/types": 6.8.0
     eslint-visitor-keys: ^3.4.1
   checksum: 710d9067b85d7715a400ae625c083c41733abb891d7b35108de083913980f9642e79d27689599fa39915f0fecae16dbfc30367007fccc838ccd917943660de22
+  languageName: node
+  linkType: hard
+
+"@vitest/coverage-v8@npm:^0.34.5":
+  version: 0.34.6
+  resolution: "@vitest/coverage-v8@npm:0.34.6"
+  dependencies:
+    "@ampproject/remapping": ^2.2.1
+    "@bcoe/v8-coverage": ^0.2.3
+    istanbul-lib-coverage: ^3.2.0
+    istanbul-lib-report: ^3.0.1
+    istanbul-lib-source-maps: ^4.0.1
+    istanbul-reports: ^3.1.5
+    magic-string: ^0.30.1
+    picocolors: ^1.0.0
+    std-env: ^3.3.3
+    test-exclude: ^6.0.0
+    v8-to-istanbul: ^9.1.0
+  peerDependencies:
+    vitest: ">=0.32.0 <1"
+  checksum: d5fe7685151bdf500278a42cde3a12afdea77b2de0d7eb069fe89e7a6010efbb9bc7cb86a2b27f00f6689d526abdc99b3fa9d97ac2bb3a0f78cd86d6d954910e
   languageName: node
   linkType: hard
 
@@ -1753,6 +1840,13 @@ __metadata:
   dependencies:
     safe-buffer: 5.2.1
   checksum: afb9d545e296a5171d7574fcad634b2fdf698875f4006a9dd04a3e1333880c5c0c98d47b560d01216fb6505a54a2ba6a843ee3a02ec86d7e911e8315255f56c3
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
   languageName: node
   linkType: hard
 
@@ -3049,6 +3143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -3418,6 +3519,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: ^3.0.0
+    make-dir: ^4.0.0
+    supports-color: ^7.1.0
+  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
+  dependencies:
+    debug: ^4.1.1
+    istanbul-lib-coverage: ^3.0.0
+    source-map: ^0.6.1
+  checksum: 21ad3df45db4b81852b662b8d4161f6446cd250c1ddc70ef96a585e2e85c26ed7cd9c2a396a71533cfb981d1a645508bc9618cae431e55d01a0628e7dec62ef2
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.5":
+  version: 3.1.7
+  resolution: "istanbul-reports@npm:3.1.7"
+  dependencies:
+    html-escaper: ^2.0.0
+    istanbul-lib-report: ^3.0.0
+  checksum: 2072db6e07bfbb4d0eb30e2700250636182398c1af811aea5032acb219d2080f7586923c09fa194029efd6b92361afb3dcbe1ebcc3ee6651d13340f7c6c4ed95
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^2.3.5":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -3759,6 +3899,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: ^7.5.3
+  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
+  languageName: node
+  linkType: hard
+
 "make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
@@ -3815,7 +3964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -4146,6 +4295,7 @@ __metadata:
     "@types/jsonwebtoken": ^9.0.2
     "@types/node": ^20.2.3
     "@types/pg": ^8.10.2
+    "@vitest/coverage-v8": ^0.34.5
     arg: ^5.0.2
     eslint: ^8.41.0
     eslint-config-codex: ^1.8.3
@@ -5398,6 +5548,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
 "spdx-exceptions@npm:^2.1.0":
   version: 2.3.0
   resolution: "spdx-exceptions@npm:2.3.0"
@@ -5716,6 +5873,17 @@ __metadata:
   dependencies:
     bintrees: 1.0.2
   checksum: 44de8246752b6f8c2924685f969fd3d94c36949f22b0907e99bef2b2220726dd8467f4730ea96b06040b9aa2587c0866049640039d1b956952dfa962bc2075a3
+  languageName: node
+  linkType: hard
+
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": ^0.1.2
+    glob: ^7.1.4
+    minimatch: ^3.0.4
+  checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
   languageName: node
   linkType: hard
 
@@ -6094,6 +6262,17 @@ __metadata:
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
+  languageName: node
+  linkType: hard
+
+"v8-to-istanbul@npm:^9.1.0":
+  version: 9.2.0
+  resolution: "v8-to-istanbul@npm:9.2.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^2.0.0
+  checksum: 31ef98c6a31b1dab6be024cf914f235408cd4c0dc56a5c744a5eea1a9e019ba279e1b6f90d695b78c3186feed391ed492380ccf095009e2eb91f3d058f0b4491
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Test coverage reports will now be commented on a corresponding PR.

I set the threshold to 80%, but we can change that.

It shows the percentage of code covered by tests and also compares your PR's coverage with the previous one (from the `main` branch)

![image](https://github.com/codex-team/notes.api/assets/59017579/1464fa51-8591-4ebd-b220-201c643e4493)
