### PR TITLE
Move team rights test data to a separate file

### DIFF
--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1,6 +1,7 @@
 import { MemberRole } from '@domain/entities/team.js';
 import { describe, test, expect, beforeEach } from 'vitest';
 import type User from '@domain/entities/user.js';
+import { memberRightsTestData } from '@tests/utils/team-rights';
 
 describe('Note API', () => {
   beforeEach(async () => {
@@ -243,38 +244,7 @@ describe('Note API', () => {
   });
 
   describe('PATCH note/:notePublicId ', () => {
-    test.each([
-      /** Returns 200 if user is team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Patch note by public id', async ({ role, isAuthorized, expectedStatusCode, expectedMessage }) => {
       /** Only if user has a Write role, he can edit the note */
       const canEdit = role === MemberRole.Write;
@@ -459,38 +429,7 @@ describe('Note API', () => {
   });
 
   describe('DELETE /note/:notePublicId', () => {
-    test.each([
-      /** Returns 200 if user is team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Delete note by public id', async ({ role, isAuthorized, expectedStatusCode, expectedMessage }) => {
       /** Create test user - creator of note */
       const creator = await global.db.insertUser();
@@ -674,38 +613,7 @@ describe('Note API', () => {
 
       accessToken = global.auth(user.id);
     });
-    test.each([
-      /** Returns 200 if user is team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Unlink any parent from note by it\'s public id', async ({ role, isAuthorized, expectedStatusCode, expectedMessage }) => {
       /* Create second user, who will be the creator of the note */
       const creator = await global.db.insertUser();

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach } from 'vitest';
 import { MemberRole } from '@domain/entities/team.js';
+import { memberRightsTestData } from '@tests/utils/team-rights';
 
 describe('NoteSettings API', () => {
   beforeEach(async () => {
@@ -12,38 +13,7 @@ describe('NoteSettings API', () => {
     await global.db.truncateTables();
   });
   describe('GET /note-settings/:notePublicId ', () => {
-    test.each([
-      /** Returns 401 when the user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
-
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 when user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 403 when user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Get note settings and team by public id', async ({ role, isAuthorized, expectedStatusCode, expectedMessage }) => {
       /** Create test user - creator of a note */
       const creator = await global.db.insertUser();
@@ -156,38 +126,7 @@ describe('NoteSettings API', () => {
   });
 
   describe('GET /note-settings/:notePublicId/team ', () => {
-    test.each([
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-
-      /** Returns 401 when the user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
-
-      /** Returns 403 when the the user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-        expectedMessage: 'Permission denied',
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Get note team by public id', async ({ role, isAuthorized, expectedStatusCode, expectedMessage }) => {
       /** Create test user - creator of a note */
       const creator = await global.db.insertUser();
@@ -282,35 +221,7 @@ describe('NoteSettings API', () => {
   });
 
   describe('PATCH /note-settings/:notePublicId ', () => {
-    test.each([
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Update note settings by public id', async ({ role, isAuthorized, expectedStatusCode }) => {
       /** Create test user - creator of a note */
       const creator = await global.db.insertUser();
@@ -399,35 +310,7 @@ describe('NoteSettings API', () => {
   });
 
   describe('PATCH /note-settings/:notePublicId/invitation-hash ', () => {
-    test.each([
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Generate invitation hash', async ({ role, isAuthorized, expectedStatusCode }) => {
       /** Create test user - creator of a note */
       const creator = await global.db.insertUser();
@@ -521,35 +404,7 @@ describe('NoteSettings API', () => {
   });
 
   describe('PATCH /note-settings/:notePublicId/team', () => {
-    test.each([
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Update team member role by user id and note id', async ({ role, isAuthorized, expectedStatusCode }) => {
       /** Create test user - creator of a note */
       const creator = await global.db.insertUser();
@@ -659,35 +514,7 @@ describe('NoteSettings API', () => {
   });
 
   describe('DELETE /:notePublicId/team', () => {
-    test.each([
-      /** Returns 200 if user is a team member with a Write role */
-      {
-        role: MemberRole.Write,
-        isAuthorized: true,
-        expectedStatusCode: 200,
-      },
-
-      /** Returns 403 if user is a team member with a Read role */
-      {
-        role: MemberRole.Read,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 403 if user is not in the team */
-      {
-        role: null,
-        isAuthorized: true,
-        expectedStatusCode: 403,
-      },
-
-      /** Returns 401 if user is not authorized */
-      {
-        role: null,
-        isAuthorized: false,
-        expectedStatusCode: 401,
-      },
-    ])
+    test.each(memberRightsTestData)
     ('Delete user from the team', async ( { role, isAuthorized, expectedStatusCode } ) => {
       const creator = await global.db.insertUser();
 

--- a/src/tests/utils/team-rights.ts
+++ b/src/tests/utils/team-rights.ts
@@ -1,0 +1,34 @@
+import { MemberRole } from '@domain/entities/team.js';
+
+export let memberRightsTestData: any[] = [
+  /** Returns 200 if user is team member with a Write role */
+  {
+    role: MemberRole.Write,
+    isAuthorized: true,
+    expectedStatusCode: 200,
+  },
+
+  /** Returns 403 if user is team member with a Read role */
+  {
+    role: MemberRole.Read,
+    isAuthorized: true,
+    expectedStatusCode: 403,
+    expectedMessage: 'Permission denied',
+  },
+
+  /** Returns 403 if user is not in the team */
+  {
+    role: null,
+    isAuthorized: true,
+    expectedStatusCode: 403,
+    expectedMessage: 'Permission denied',
+  },
+
+  /** Returns 401 if user is not authorized */
+  {
+    role: null,
+    isAuthorized: false,
+    expectedStatusCode: 401,
+    expectedMessage: 'You must be authenticated to access this resource',
+  },
+];


### PR DESCRIPTION
Moved test data for test.each block about team rights into a separate file for more convenient usage.