### PR TITLE
Fix: domain error handler doesn't work

### DIFF
--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -70,6 +70,8 @@ export default class HttpApi implements Api {
      *
      * @see https://fastify.dev/docs/latest/Guides/Getting-Started#loading-order-of-your-plugins
      */
+    this.domainErrorHandler();
+
     await this.addCookies();
     await this.addOpenapiDocs();
     await this.addOpenapiUI();
@@ -83,8 +85,6 @@ export default class HttpApi implements Api {
 
     await this.addPoliciesCheckHook(domainServices);
     await this.addApiRoutes(domainServices);
-
-    this.domainErrorHandler();
   }
 
 
@@ -353,6 +353,11 @@ export default class HttpApi implements Api {
         this.log.error(error);
         void reply.domainError(error.message);
       }
+
+      /**
+       * If error is not a domain error, we route it to the default error handler
+       */
+      throw error;
     });
   }
 }


### PR DESCRIPTION
Closes #199 

To fix this, domain error handler is now initialized earlier (https://githubissues.com/fastify/help/911 like in this issue)

Also, if error is not a domain error, we route it to the default error handler. Otherwise error won't be handled