### PR TITLE
Feat: check to prevent circular reference

### DIFF
--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -177,13 +177,19 @@ export default class NoteService {
       throw new DomainError(`Incorrect parent note`);
     }
 
-    if (parentNote.id === noteId) {
-      throw new DomainError(`Parent note is the same as the child note`);
-    }
+    let parentNoteId: number | null = parentNote.id;
 
     /**
-     * @todo: add check, that new parent is not in childNotes to avoid circular references
+     * This loop checks for cyclic reference when updating a note's parent.
      */
+    while (parentNoteId != null) {
+      if (parentNoteId === noteId) {
+        throw new DomainError(`Note with ID ${noteId} cannot be a child of Note with ID ${parentNote.id}`);
+      }
+
+      parentNoteId = await this.noteRelationsRepository.getParentNoteIdByNoteId(parentNoteId);
+    }
+
     return await this.noteRelationsRepository.updateNoteRelationById(noteId, parentNote.id);
   };
 }

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1086,7 +1086,7 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(400);
 
-      expect(response?.json().message).toStrictEqual('Parent note is the same as the child note');
+      expect(response?.json().message).toStrictEqual(`Note with ID ${childNote.id} cannot be a child of Note with ID ${childNote.id}`);
     });
 
     test('Return 400 when parent note does not exist', async () => {
@@ -1110,6 +1110,37 @@ describe('Note API', () => {
       expect(response?.statusCode).toBe(400);
 
       expect(response?.json().message).toStrictEqual('Incorrect parent note');
+    });
+
+    test('Return 400 when circular reference occurs', async () => {
+      const parentNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+
+      await global.db.insertNoteRelation({
+        noteId: childNote.id,
+        parentId: parentNote.id,
+      });
+
+      const response = await global.api?.fakeRequest({
+        method: 'PATCH',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: childNote.publicId,
+        },
+        url: `/note/${parentNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(400);
+
+      expect(response?.json().message).toStrictEqual(`Note with ID ${parentNote.id} cannot be a child of Note with ID ${childNote.id}`);
     });
   });
 });


### PR DESCRIPTION
The service method now throws an error if one of the parents is the same as the current note.