### PR TITLE
Feat(TS): Change typescript compiler module

### DIFF
--- a/src/domain/entities/editorTools.ts
+++ b/src/domain/entities/editorTools.ts
@@ -1,4 +1,4 @@
-import type User from './user';
+import type User from './user.js';
 
 /**
  * Plugin that connects to the editor based on user settings

--- a/src/domain/entities/notePublic.ts
+++ b/src/domain/entities/notePublic.ts
@@ -1,4 +1,4 @@
-import type { Note } from '@domain/entities/note';
+import type { Note } from '@domain/entities/note.js';
 
 type NotePublicProperties = 'content' | 'createdAt' | 'updatedAt'| 'creatorId';
 

--- a/src/domain/entities/user.ts
+++ b/src/domain/entities/user.ts
@@ -1,4 +1,4 @@
-import type EditorTool from './editorTools';
+import type EditorTool from './editorTools.js';
 
 /**
  * User entity

--- a/src/domain/service/ai.ts
+++ b/src/domain/service/ai.ts
@@ -1,4 +1,4 @@
-import type AIRepository from '@repository/ai.repository';
+import type AIRepository from '@repository/ai.repository.js';
 
 /**
  * AI service

--- a/src/domain/service/noteList.ts
+++ b/src/domain/service/noteList.ts
@@ -1,5 +1,5 @@
-import type NoteRepository from '@repository/note.repository';
-import type { NoteList } from '@domain/entities/noteList';
+import type NoteRepository from '@repository/note.repository.js';
+import type { NoteList } from '@domain/entities/noteList.js';
 
 /**
  * Note list service

--- a/src/domain/service/noteVisits.ts
+++ b/src/domain/service/noteVisits.ts
@@ -1,7 +1,7 @@
-import type { NoteInternalId } from '@domain/entities/note';
+import type { NoteInternalId } from '@domain/entities/note.js';
 import type User from '@domain/entities/user.js';
 import type NoteVisit from '@domain/entities/noteVisit.js';
-import type NoteVisitsRepository from '@repository/noteVisits.repository';
+import type NoteVisitsRepository from '@repository/noteVisits.repository.js';
 
 /**
  * Note Visits service, which will store latest note visit

--- a/src/domain/service/shared/editorTools.ts
+++ b/src/domain/service/shared/editorTools.ts
@@ -1,4 +1,4 @@
-import type EditorTool from '@domain/entities/editorTools';
+import type EditorTool from '@domain/entities/editorTools.js';
 
 /**
  * Which methods of Domain can be used by other domains

--- a/src/domain/service/shared/index.ts
+++ b/src/domain/service/shared/index.ts
@@ -1,5 +1,5 @@
-import type EditorToolsServiceSharedMethods from './editorTools';
-import type NoteServiceSharedMethods from './note';
+import type EditorToolsServiceSharedMethods from './editorTools.js';
+import type NoteServiceSharedMethods from './note.js';
 
 export type SharedDomainMethods = {
   editorTools: EditorToolsServiceSharedMethods;

--- a/src/domain/service/shared/note.ts
+++ b/src/domain/service/shared/note.ts
@@ -1,4 +1,4 @@
-import type { NoteInternalId } from '@domain/entities/note';
+import type { NoteInternalId } from '@domain/entities/note.js';
 
 /**
  * Which methods of Domain can be used by other domains

--- a/src/domain/service/user.ts
+++ b/src/domain/service/user.ts
@@ -1,7 +1,7 @@
 import type UserRepository from '@repository/user.repository.js';
 import { Provider } from '@repository/user.repository.js';
 import type User from '@domain/entities/user.js';
-import type EditorTool from '@domain/entities/editorTools';
+import type EditorTool from '@domain/entities/editorTools.js';
 import type { SharedDomainMethods } from './shared/index.js';
 import { DomainError } from '@domain/entities/DomainError.js';
 

--- a/src/presentation/api.interface.ts
+++ b/src/presentation/api.interface.ts
@@ -1,4 +1,4 @@
-import type { DomainServices } from '@domain/index';
+import type { DomainServices } from '@domain/index.js';
 import type * as http from 'http';
 
 /**

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -5,7 +5,7 @@ import fastify from 'fastify';
 import type Api from '@presentation/api.interface.js';
 import type { DomainServices } from '@domain/index.js';
 import cors from '@fastify/cors';
-import fastifyOauth2 from '@fastify/oauth2';
+import { fastifyOauth2 } from '@fastify/oauth2';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUI from '@fastify/swagger-ui';
 import addUserIdResolver from '@presentation/http/middlewares/common/userIdResolver.js';

--- a/src/presentation/http/router/ai.ts
+++ b/src/presentation/http/router/ai.ts
@@ -1,4 +1,4 @@
-import type AIService from '@domain/service/ai';
+import type AIService from '@domain/service/ai.js';
 import type { FastifyPluginCallback } from 'fastify';
 
 /**

--- a/src/presentation/http/router/noteList.test.ts
+++ b/src/presentation/http/router/noteList.test.ts
@@ -1,4 +1,4 @@
-import type User from '@domain/entities/user';
+import type User from '@domain/entities/user.js';
 import { describe, test, expect, beforeEach } from 'vitest';
 
 let accessToken = '';

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type NoteListService from '@domain/service/noteList.js';
 import { definePublicNote, type NotePublic } from '@domain/entities/notePublic.js';
-import type { NoteListPublic } from '@domain/entities/noteList';
+import type { NoteListPublic } from '@domain/entities/noteList.js';
 
 
 /**

--- a/src/presentation/http/router/user.ts
+++ b/src/presentation/http/router/user.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type UserService from '@domain/service/user.js';
 import type User from '@domain/entities/user.js';
-import type EditorToolsService from '@domain/service/editorTools';
+import type EditorToolsService from '@domain/service/editorTools.js';
 
 /**
  * Interface for the user router

--- a/src/presentation/http/types/PolicyContext.ts
+++ b/src/presentation/http/types/PolicyContext.ts
@@ -1,4 +1,4 @@
-import type { DomainServices } from '@domain/index';
+import type { DomainServices } from '@domain/index.js';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
 /**

--- a/src/repository/ai.repository.ts
+++ b/src/repository/ai.repository.ts
@@ -1,6 +1,6 @@
 import { notEmpty } from '@infrastructure/utils/empty.js';
-import type OpenAIApi from './transport/openai-api';
-import type { GetCompletionResponsePayload } from './transport/openai-api/types/GetCompletionResponsePayload';
+import type OpenAIApi from './transport/openai-api/index.js';
+import type { GetCompletionResponsePayload } from './transport/openai-api/types/GetCompletionResponsePayload.js';
 
 /**
  * Repository that establishes access to data from business logic

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -3,8 +3,8 @@ import { DataTypes, Model } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
 import type { Note, NoteCreationAttributes, NoteInternalId, NotePublicId } from '@domain/entities/note.js';
 import { UserModel } from '@repository/storage/postgres/orm/sequelize/user.js';
-import type { NoteSettingsModel } from './noteSettings';
-import { NoteList } from '@domain/entities/noteList';
+import type { NoteSettingsModel } from './noteSettings.js';
+import { NoteList } from '@domain/entities/noteList.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 

--- a/src/repository/storage/postgres/orm/sequelize/noteRelations.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteRelations.ts
@@ -3,7 +3,7 @@ import { Op } from 'sequelize';
 import { NoteModel } from '@repository/storage/postgres/orm/sequelize/note.js';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
 import type { NoteInternalId } from '@domain/entities/note.js';
-import type { Note } from '@domain/entities/note';
+import type { Note } from '@domain/entities/note.js';
 import { Model, DataTypes } from 'sequelize';
 
 /**

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -3,7 +3,7 @@ import { literal } from 'sequelize';
 import { Model, DataTypes } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
 import type User from '@domain/entities/user.js';
-import type EditorTool from '@domain/entities/editorTools';
+import type EditorTool from '@domain/entities/editorTools.js';
 
 /**
  * Query options for getting user

--- a/src/repository/team.repository.ts
+++ b/src/repository/team.repository.ts
@@ -1,7 +1,7 @@
 import type TeamStorage from '@repository/storage/team.storage.js';
 import type { Team, TeamMember, TeamMemberCreationAttributes, MemberRole } from '@domain/entities/team.js';
-import type { NoteInternalId } from '@domain/entities/note';
-import type User from '@domain/entities/user';
+import type { NoteInternalId } from '@domain/entities/note.js';
+import type User from '@domain/entities/user.js';
 
 /**
  * Repository allows accessing data from business-logic (domain) level

--- a/src/repository/transport/openai-api/index.ts
+++ b/src/repository/transport/openai-api/index.ts
@@ -1,6 +1,6 @@
 import Transport from '@repository/transport/index.js';
 import appConfig from '@infrastructure/config/index.js'; // @todo get rid of import from infrastructure
-import type { ApiResponse } from '../google-api/types/ApiResponse';
+import type { ApiResponse } from '../google-api/types/ApiResponse.js';
 
 /**
  * OpenAI transport

--- a/src/repository/transport/openai-api/types/ApiResponse.ts
+++ b/src/repository/transport/openai-api/types/ApiResponse.ts
@@ -1,4 +1,4 @@
-import type { GetCompletionResponsePayload } from './GetCompletionResponsePayload';
+import type { GetCompletionResponsePayload } from './GetCompletionResponsePayload.js';
 
 /**
  * Payload of the OpenAI API responses

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -2,8 +2,8 @@ import type User from '@domain/entities/user.js';
 import type UserStorage from '@repository/storage/user.storage.js';
 import type GoogleApiTransport from '@repository/transport/google-api/index.js';
 import type GetUserInfoResponsePayload from '@repository/transport/google-api/types/GetUserInfoResponsePayload.js';
-import type { AddUserToolOptions } from '@repository/storage/postgres/orm/sequelize/user';
-import type EditorTool from '@domain/entities/editorTools';
+import type { AddUserToolOptions } from '@repository/storage/postgres/orm/sequelize/user.js';
+import type EditorTool from '@domain/entities/editorTools.js';
 
 /**
  * OAuth provider

--- a/src/tests/utils/database-helpers.ts
+++ b/src/tests/utils/database-helpers.ts
@@ -1,5 +1,5 @@
-import { createInvitationHash } from '@infrastructure/utils/invitationHash';
-import { createPublicId } from '@infrastructure/utils/id';
+import { createInvitationHash } from '@infrastructure/utils/invitationHash.js';
+import { createPublicId } from '@infrastructure/utils/id.js';
 import { QueryTypes } from 'sequelize';
 import type User from '@domain/entities/user.ts';
 import type { Note } from '@domain/entities/note.ts';

--- a/src/tests/utils/setup.ts
+++ b/src/tests/utils/setup.ts
@@ -2,15 +2,15 @@ import path from 'path';
 import type { StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 
-import { insertData } from './insert-data';
+import { insertData } from './insert-data.js';
 import { initORM, init as initRepositories } from '@repository/index.js';
 import { init as initDomainServices } from '@domain/index.js';
 import config from '@infrastructure/config/index.js';
-import { runTenantMigrations } from '@repository/storage/postgres/migrations/migrate';
+import { runTenantMigrations } from '@repository/storage/postgres/migrations/migrate.js';
 import API from '@presentation/index.js';
 
 import { beforeAll, afterAll } from 'vitest';
-import type Api from '@presentation/api.interface';
+import type Api from '@presentation/api.interface.js';
 
 import DatabaseHelpers from './database-helpers.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "baseUrl": "./src" ,
     "target": "es2022",
-    "module": "es2022",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
# Problem
Current typescript compiler's module isn't validating that imports have explicit 'js' extensions.
Missing extensions can break the app.

# Solution
Change the module to `node16`. Add missing extensions. 