### PR TITLE
Save noteVisit on note creation

### DIFF
--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -225,6 +225,14 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const addedNote = await noteService.addNote(content as JSON, userId as number, parentId); // "authRequired" policy ensures that userId is not null
 
     /**
+     * Save note visit when note created
+     *
+     * @todo use even bus to save noteVisit
+     */
+    if (userId !== null) {
+      await noteVisitsService.saveVisit(addedNote.id, userId);
+    }
+    /**
      * @todo use event bus: emit 'note-added' event and subscribe to it in other modules like 'note-settings'
      */
     await noteSettingsService.addNoteSettings(addedNote.id);

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -229,9 +229,9 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
      *
      * @todo use even bus to save noteVisit
      */
-    if (userId !== null) {
-      await noteVisitsService.saveVisit(addedNote.id, userId);
-    }
+
+    await noteVisitsService.saveVisit(addedNote.id, userId!);
+
     /**
      * @todo use event bus: emit 'note-added' event and subscribe to it in other modules like 'note-settings'
      */


### PR DESCRIPTION
## Problem
- Note visits are not saved, when user created the note

## Solution
- Now on POST note endpoint noteVIsit saved

- left todo for event bus usage