### PR TITLE
chore[migrations]: added migration for note data

### DIFF
--- a/migrations/tenant/0031-note@add-tools-for-notes-that-do-not-have-ones.sql
+++ b/migrations/tenant/0031-note@add-tools-for-notes-that-do-not-have-ones.sql
@@ -1,0 +1,19 @@
+DO $$
+DECLARE
+    note_record RECORD;
+BEGIN
+    -- Обходим каждую запись в таблице
+    FOR note_record IN SELECT * FROM public.notes LOOP
+        -- Обновляем поле tools для каждой записи
+        UPDATE public.notes
+        SET tools = (
+            SELECT jsonb_agg(jsonb_build_object('id', tool.id, 'name', tool.name))
+            FROM (
+                SELECT DISTINCT block->>'type' AS type
+                FROM json_array_elements(note_record.content->'blocks') AS block
+            ) AS content
+            JOIN public.editor_tools tool ON content.type = tool.name
+        )
+        WHERE id = note_record.id; -- Обновляем только текущую запись
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Problem
We recently added tools field for `public.note` table, and now tools are inserted on appropriate routes
See #251 for more information
But old notes that were in table before tools field implementation are now having null in tools

## Solution
Added migration that checks for note tools inside `content.blocks` of each note and adds appropriate array into `tools` field