### PR TITLE
Feature: Add POST  /note/:notePublicId/relation route

### DIFF
--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -196,6 +196,43 @@ export default class NoteService {
   }
 
   /**
+   * Create note relation
+   * @param noteId - id of the current note
+   * @param parentPublicId - id of the parent note
+   */
+  public async createNoteRelation(noteId: NoteInternalId, parentPublicId: NotePublicId): Promise<boolean> {
+    const currenParentNote = await this.noteRelationsRepository.getParentNoteIdByNoteId(noteId);
+
+    /**
+     * Check if the note already has a parent
+     */
+    if (currenParentNote !== null) {
+      throw new DomainError(`Note already has parent note`);
+    }
+
+    const parentNote = await this.noteRepository.getNoteByPublicId(parentPublicId);
+
+    if (parentNote === null) {
+      throw new DomainError(`Incorrect parent note`);
+    }
+
+    let parentNoteId: number | null = parentNote.id;
+
+    /**
+     * This loop checks for cyclic reference when updating a note's parent.
+     */
+    while (parentNoteId !== null) {
+      if (parentNoteId === noteId) {
+        throw new DomainError(`Forbidden relation. Note can't be a child of own child`);
+      }
+
+      parentNoteId = await this.noteRelationsRepository.getParentNoteIdByNoteId(parentNoteId);
+    }
+
+    return await this.noteRelationsRepository.addNoteRelation(noteId, parentNote.id);
+  }
+
+  /**
    * Update note relation
    * @param noteId - id of the current note
    * @param parentPublicId - id of the new parent note

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -200,7 +200,7 @@ export default class NoteService {
    * @param noteId - id of the current note
    * @param parentPublicId - id of the parent note
    */
-  public async createNoteRelation(noteId: NoteInternalId, parentPublicId: NotePublicId): Promise<boolean> {
+  public async createNoteRelation(noteId: NoteInternalId, parentPublicId: NotePublicId): Promise<Note> {
     const currenParentNote = await this.noteRelationsRepository.getParentNoteIdByNoteId(noteId);
 
     /**
@@ -213,7 +213,7 @@ export default class NoteService {
     const parentNote = await this.noteRepository.getNoteByPublicId(parentPublicId);
 
     if (parentNote === null) {
-      throw new DomainError(`Incorrect parent note`);
+      throw new DomainError(`Incorrect parent note Id`);
     }
 
     let parentNoteId: number | null = parentNote.id;
@@ -229,7 +229,13 @@ export default class NoteService {
       parentNoteId = await this.noteRelationsRepository.getParentNoteIdByNoteId(parentNoteId);
     }
 
-    return await this.noteRelationsRepository.addNoteRelation(noteId, parentNote.id);
+    const isCreated = await this.noteRelationsRepository.addNoteRelation(noteId, parentNote.id);
+
+    if (!isCreated) {
+      throw new DomainError(`Relation was not created`);
+    }
+
+    return parentNote;
   }
 
   /**

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1436,6 +1436,179 @@ describe('Note API', () => {
     });
   });
 
+  describe('POST /note/:notePublicId/relation', () => {
+    let accessToken = '';
+    let user: User;
+
+    beforeEach(async () => {
+      /** create test user */
+      user = await global.db.insertUser();
+
+      accessToken = global.auth(user.id);
+    });
+    test('Returns 200 and isCreated=true when relation was successfully created', async () => {
+      /* create test child note */
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /* create test parent note */
+      const parentNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /* create note settings for child note */
+      await global.db.insertNoteSetting({
+        noteId: childNote.id,
+        isPublic: true,
+      });
+
+      let response = await global.api?.fakeRequest({
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: parentNote.publicId,
+        },
+        url: `/note/${childNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(200);
+
+      expect(response?.json().isCreated).toBe(true);
+
+      response = await global.api?.fakeRequest({
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note/${childNote.publicId}`,
+      });
+
+      expect(response?.json().parentNote.id).toBe(parentNote.publicId);
+    });
+
+    test('Returns 400 when note already has parent note', async () => {
+      /* create test child note */
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /* create test parent note */
+      const parentNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /* create test note, that will be new parent for the child note */
+      const newParentNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /* create note settings for child note */
+      await global.db.insertNoteSetting({
+        noteId: childNote.id,
+        isPublic: true,
+      });
+
+      /* create test relation */
+      await global.db.insertNoteRelation({
+        noteId: childNote.id,
+        parentId: parentNote.id,
+      });
+
+      let response = await global.api?.fakeRequest({
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: newParentNote.publicId,
+        },
+        url: `/note/${childNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(400);
+
+      expect(response?.json().message).toStrictEqual('Note already has parent note');
+    });
+
+    test('Returns 400 when parent is the same as child', async () => {
+      /* create test child note */
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      const response = await global.api?.fakeRequest({
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: childNote.publicId,
+        },
+        url: `/note/${childNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(400);
+
+      expect(response?.json().message).toStrictEqual(`Forbidden relation. Note can't be a child of own child`);
+    });
+
+    test('Return 400 when parent note does not exist', async () => {
+      const nonExistentParentId = '47L43yY7dp';
+
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      const response = await global.api?.fakeRequest({
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: nonExistentParentId,
+        },
+        url: `/note/${childNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(400);
+
+      expect(response?.json().message).toStrictEqual('Incorrect parent note');
+    });
+
+    test('Return 400 when circular reference occurs', async () => {
+      const parentNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      const childNote = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      await global.db.insertNoteRelation({
+        noteId: childNote.id,
+        parentId: parentNote.id,
+      });
+
+      const response = await global.api?.fakeRequest({
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        body: {
+          parentNoteId: childNote.publicId,
+        },
+        url: `/note/${parentNote.publicId}/relation`,
+      });
+
+      expect(response?.statusCode).toBe(400);
+
+      expect(response?.json().message).toStrictEqual(`Forbidden relation. Note can't be a child of own child`);
+    });
+  });
+
   describe('PATCH /note/:notePublicId', () => {
     const tools = [headerTool, listTool];
 

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1505,12 +1505,6 @@ describe('Note API', () => {
         creatorId: user.id,
       });
 
-      /* create note settings for child note */
-      await global.db.insertNoteSetting({
-        noteId: childNote.id,
-        isPublic: true,
-      });
-
       /* create test relation */
       await global.db.insertNoteRelation({
         noteId: childNote.id,

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1476,8 +1476,6 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(200);
 
-      expect(response?.json().isCreated).toBe(true);
-
       response = await global.api?.fakeRequest({
         method: 'GET',
         headers: {
@@ -1569,7 +1567,7 @@ describe('Note API', () => {
 
       expect(response?.statusCode).toBe(400);
 
-      expect(response?.json().message).toStrictEqual('Incorrect parent note');
+      expect(response?.json().message).toStrictEqual('Incorrect parent note Id');
     });
 
     test('Return 400 when circular reference occurs', async () => {

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -400,10 +400,9 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       response: {
         '2xx': {
           type: 'object',
-          description: 'Parent note',
           properties: {
             parentNote: {
-              type: 'Note',
+              $ref: 'NoteSchema#',
             },
           },
         },

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -373,6 +373,61 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
   });
 
   /**
+   * Create note relation by id.
+   */
+  fastify.post<{
+    Params: {
+      notePublicId: NotePublicId;
+    };
+    Body: {
+      parentNoteId: NotePublicId;
+    };
+    Reply: {
+      isCreated: boolean;
+    };
+  }>('/:notePublicId/relation', {
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+      body: {
+        parentNoteId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+      response: {
+        '2xx': {
+          type: 'object',
+          description: 'Was the relation created',
+          properties: {
+            isCreated: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    },
+    config: {
+      policy: [
+        'authRequired',
+        'userCanEdit',
+      ],
+    },
+    preHandler: [
+      noteResolver,
+    ],
+  }, async (request, reply) => {
+    const noteId = request.note?.id as number;
+    const parentNoteId = request.body.parentNoteId;
+
+    const isCreated = await noteService.createNoteRelation(noteId, parentNoteId);
+
+    return reply.send({ isCreated });
+  });
+
+  /**
    * Update note relation by id.
    */
   fastify.patch<{

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -383,7 +383,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       parentNoteId: NotePublicId;
     };
     Reply: {
-      isCreated: boolean;
+      parentNote: Note;
     };
   }>('/:notePublicId/relation', {
     schema: {
@@ -400,10 +400,10 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       response: {
         '2xx': {
           type: 'object',
-          description: 'Was the relation created',
+          description: 'Parent note',
           properties: {
-            isCreated: {
-              type: 'boolean',
+            parentNote: {
+              type: 'Note',
             },
           },
         },
@@ -422,9 +422,9 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const noteId = request.note?.id as number;
     const parentNoteId = request.body.parentNoteId;
 
-    const isCreated = await noteService.createNoteRelation(noteId, parentNoteId);
+    const parentNote = await noteService.createNoteRelation(noteId, parentNoteId);
 
-    return reply.send({ isCreated });
+    return reply.send({ parentNote });
   });
 
   /**


### PR DESCRIPTION
This creates a relation for an already existing note. We use it when we want to set parent note for an existing note. 
Also, tests added for this route