### PR TITLE
feat: return fields updatedAt and createdAt with note

### DIFF
--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -600,6 +600,65 @@ describe('Note API', () => {
       }
     });
 
+    test('UpdatedAt field is updated when note is modified', async () => {
+      /** Create test user */
+      const user = await global.db.insertUser();
+
+      const accessToken = global.auth(user.id);
+
+      /** Create test note */
+      let note = await global.db.insertNote({
+        creatorId: user.id,
+      });
+
+      /** Create test note settings */
+      await global.db.insertNoteSetting({
+        noteId: note.id,
+        isPublic: true,
+      });
+
+      /** Save the original value of updatedAt */
+      const originalUpdatedAt = note.updatedAt;
+
+      const newContent = {
+        blocks: [
+          {
+            id: 'qxnjUh9muR',
+            type: headerTool.name,
+            data: {
+              text: 'sample text',
+              level: 1,
+            },
+          },
+        ],
+      };
+
+      const newTools = [
+        {
+          name: headerTool.name,
+          id: headerTool.id,
+        },
+      ];
+
+      /** Modify the note */
+      const response = await global.api?.fakeRequest({
+        method: 'PATCH',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        url: `/note/${note.publicId}`,
+        body: {
+          content: newContent,
+          tools: newTools,
+        },
+      });
+
+      /** Check if note was modified successfully */
+      expect(response?.statusCode).toBe(200);
+
+      expect(response?.json().updatedAt).not.toEqual(originalUpdatedAt);
+    });
+
     test('Returns status 406 when the public id does not exist', async () => {
       const nonexistentId = 'ishvm5qH84';
 

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -236,6 +236,10 @@ describe('Note API', () => {
           },
           tools: [headerTool, paragraphTool],
         });
+
+        /** Check if response has createdAt and updatedAt fields */
+        expect(response?.json().note.createdAt).not.toBeNull();
+        expect(response?.json().note.updatedAt).not.toBeNull();
       } else {
         expect(response?.json()).toStrictEqual({
           message: expectedMessage,

--- a/src/presentation/http/schema/Note.ts
+++ b/src/presentation/http/schema/Note.ts
@@ -28,5 +28,13 @@ export const NoteSchema = {
         },
       },
     },
+    createdAt: {
+      type: 'string',
+      format: 'date-time',
+    },
+    updatedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
   },
 };


### PR DESCRIPTION
To display some fields in note settings we need to know, when was note updated

Whats done:
- Added fields createdAt and updatedAt to note schema

Result: We get fields createdAt and updatedAt in response with note

