### PR TITLE
chore(team): Implemented public team member

### DIFF
--- a/src/domain/entities/team.ts
+++ b/src/domain/entities/team.ts
@@ -42,7 +42,7 @@ export interface TeamMember {
 /**
  * Team member public entity sends to user with public id of the note
  */
-export type TeamMemberPublic = Omit<TeamMember, 'noteId'> & { noteId: NotePublicId };
+export type TeamMemberPublic = Omit<TeamMember, 'noteId' | 'id'> & { noteId: NotePublicId };
 
 export type Team = TeamMember[];
 

--- a/src/domain/entities/team.ts
+++ b/src/domain/entities/team.ts
@@ -1,4 +1,4 @@
-import type { NoteInternalId } from './note.js';
+import type { NoteInternalId, NotePublicId } from './note.js';
 import type User from './user.js';
 
 export enum MemberRole {
@@ -38,6 +38,11 @@ export interface TeamMember {
    */
   role: MemberRole;
 }
+
+/**
+ * Team member public entity sends to user with public id of the note
+ */
+export type TeamMemberPublic = Omit<TeamMember, 'noteId'> & { noteId: NotePublicId };
 
 export type Team = TeamMember[];
 

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -320,6 +320,10 @@ export default class NoteService {
   public async getNotePublicIdByInternal(id: NoteInternalId): Promise<NotePublicId> {
     const note = await this.noteRepository.getNoteById(id);
 
-    return note!.publicId;
+    if (note === null) {
+      throw new DomainError(`Note with id ${id}was not found`);
+    }
+
+    return note.publicId;
   }
 }

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -310,4 +310,16 @@ export default class NoteService {
       throw new DomainError('Incorrect tools passed');
     }
   }
+
+  /**
+   * Get note public id by it's internal id
+   * Used for making entities that use NoteInternalId public
+   * @param id - internal id of the note
+   * @returns note public id
+   */
+  public async getNotePublicIdByInternal(id: NoteInternalId): Promise<NotePublicId> {
+    const note = await this.noteRepository.getNoteById(id);
+
+    return note!.publicId;
+  }
 }

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -321,7 +321,7 @@ export default class NoteService {
     const note = await this.noteRepository.getNoteById(id);
 
     if (note === null) {
-      throw new DomainError(`Note with id ${id}was not found`);
+      throw new DomainError(`Note with id ${id} was not found`);
     }
 
     return note.publicId;

--- a/src/domain/service/noteSettings.ts
+++ b/src/domain/service/noteSettings.ts
@@ -3,7 +3,7 @@ import type { InvitationHash } from '@domain/entities/noteSettings.js';
 import type NoteSettings from '@domain/entities/noteSettings.js';
 import type NoteSettingsRepository from '@repository/noteSettings.repository.js';
 import type TeamRepository from '@repository/team.repository.js';
-import type { Team, TeamMember, TeamMemberCreationAttributes } from '@domain/entities/team.js';
+import type { Team, TeamMember, TeamMemberPublic, TeamMemberCreationAttributes } from '@domain/entities/team.js';
 import { MemberRole } from '@domain/entities/team.js';
 import type User from '@domain/entities/user.js';
 import { createInvitationHash } from '@infrastructure/utils/invitationHash.js';
@@ -38,7 +38,7 @@ export default class NoteSettingsService {
    * @param invitationHash - hash for joining to the team
    * @param userId - user to add
    */
-  public async addUserToTeamByInvitationHash(invitationHash: InvitationHash, userId: User['id']): Promise<TeamMember | null> {
+  public async addUserToTeamByInvitationHash(invitationHash: InvitationHash, userId: User['id']): Promise<TeamMemberPublic | null> {
     const defaultUserRole = MemberRole.Read;
     const noteSettings = await this.noteSettingsRepository.getNoteSettingsByInvitationHash(invitationHash);
 
@@ -58,11 +58,18 @@ export default class NoteSettingsService {
       throw new DomainError(`User already in team`);
     }
 
-    return await this.teamRepository.createTeamMembership({
+    const teamMember = await this.teamRepository.createTeamMembership({
       noteId: noteSettings.noteId,
       userId,
       role: defaultUserRole,
     });
+
+    return {
+      id: teamMember.id,
+      noteId: await this.shared.note.getNotePublicIdByInternal(teamMember.noteId),
+      userId: teamMember.userId,
+      role: teamMember.role,
+    };
   }
 
   /**

--- a/src/domain/service/noteSettings.ts
+++ b/src/domain/service/noteSettings.ts
@@ -50,12 +50,16 @@ export default class NoteSettingsService {
     }
 
     /**
-     * Check if user not already in team
+     * Try to get team member by user and note id
      */
-    const isUserTeamMember = await this.teamRepository.isUserInTeam(userId, noteSettings.noteId);
+    const member = await this.teamRepository.getTeamMemberByNoteAndUserId(userId, noteSettings.noteId);
 
-    if (isUserTeamMember) {
-      throw new DomainError(`User already in team`);
+    if (member !== null) {
+      return {
+        noteId: await this.shared.note.getNotePublicIdByInternal(member.noteId),
+        userId: member.userId,
+        role: member.role,
+      };
     }
 
     const teamMember = await this.teamRepository.createTeamMembership({
@@ -65,7 +69,6 @@ export default class NoteSettingsService {
     });
 
     return {
-      id: teamMember.id,
       noteId: await this.shared.note.getNotePublicIdByInternal(teamMember.noteId),
       userId: teamMember.userId,
       role: teamMember.role,

--- a/src/domain/service/shared/note.ts
+++ b/src/domain/service/shared/note.ts
@@ -1,4 +1,5 @@
 import type { NoteInternalId } from '@domain/entities/note.js';
+import type { NotePublicId } from '@domain/entities/note.js';
 
 /**
  * Which methods of Domain can be used by other domains
@@ -11,4 +12,11 @@ export default interface NoteServiceSharedMethods {
    * @param noteId - id of the current note
    */
   getParentNoteIdByNoteId(noteId: NoteInternalId): Promise<NoteInternalId | null>;
+
+  /**
+   * Get note public id by it's internal id
+   * Used for making entities that use NoteInternalId public
+   * @param id - internal id of the note
+   */
+  getNotePublicIdByInternal(noteId: NoteInternalId): Promise<NotePublicId>;
 }

--- a/src/presentation/http/router/join.test.ts
+++ b/src/presentation/http/router/join.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'vitest';
 
 describe('Join API', () => {
   describe('POST /join/:hash', () => {
-    test('Returns 406 when user is already in the team', async () => {
+    test('Returns 200 and teamMember when user is already in the team', async () => {
       const invitationHash = 'Hzh2hy4igf';
 
       /**
@@ -45,7 +45,15 @@ describe('Join API', () => {
         url: `/join/${invitationHash}`,
       });
 
-      expect(response?.statusCode).toBe(406);
+      expect(response?.statusCode).toBe(200);
+
+      expect(response?.json()).toMatchObject({
+        result: {
+          userId: user.id,
+          noteId: note.publicId,
+          role: 0,
+        },
+      });
 
       expect(response?.json()).toStrictEqual({
         message: 'User already in team',

--- a/src/presentation/http/router/join.test.ts
+++ b/src/presentation/http/router/join.test.ts
@@ -46,10 +46,6 @@ describe('Join API', () => {
         noteId: note.publicId,
         role: 1,
       });
-
-      expect(response?.json()).toStrictEqual({
-        message: 'User already in team',
-      });
     });
     test('Returns 406 when invitation hash is not valid', async () => {
       const hash = 'Jih23y4igf';

--- a/src/presentation/http/router/join.test.ts
+++ b/src/presentation/http/router/join.test.ts
@@ -28,12 +28,6 @@ describe('Join API', () => {
         invitationHash,
       });
 
-      await global.db.insertNoteTeam({
-        userId: user.id,
-        noteId: note.id,
-        role: 0,
-      });
-
       const accessToken = global.auth(user.id);
 
       /** add same user to the same note team */
@@ -50,7 +44,7 @@ describe('Join API', () => {
       expect(response?.json()).toMatchObject({
         userId: user.id,
         noteId: note.publicId,
-        role: 0,
+        role: 1,
       });
 
       expect(response?.json()).toStrictEqual({

--- a/src/presentation/http/router/join.test.ts
+++ b/src/presentation/http/router/join.test.ts
@@ -114,7 +114,7 @@ describe('Join API', () => {
       expect(response?.json()).toMatchObject({
         result: {
           userId: randomGuy.id,
-          noteId: note.id,
+          noteId: note.publicId,
           role: 0,
         },
       });

--- a/src/presentation/http/router/join.test.ts
+++ b/src/presentation/http/router/join.test.ts
@@ -48,11 +48,9 @@ describe('Join API', () => {
       expect(response?.statusCode).toBe(200);
 
       expect(response?.json()).toMatchObject({
-        result: {
-          userId: user.id,
-          noteId: note.publicId,
-          role: 0,
-        },
+        userId: user.id,
+        noteId: note.publicId,
+        role: 0,
       });
 
       expect(response?.json()).toStrictEqual({
@@ -120,11 +118,9 @@ describe('Join API', () => {
       expect(response?.statusCode).toBe(200);
 
       expect(response?.json()).toMatchObject({
-        result: {
-          userId: randomGuy.id,
-          noteId: note.publicId,
-          role: 0,
-        },
+        userId: randomGuy.id,
+        noteId: note.publicId,
+        role: 0,
       });
     });
   });

--- a/src/presentation/http/router/join.ts
+++ b/src/presentation/http/router/join.ts
@@ -65,7 +65,7 @@ const JoinRouter: FastifyPluginCallback<JoinRouterOptions> = (fastify, opts, don
       return reply.notAcceptable(causedError.message);
     }
 
-    return reply.send({ result });
+    return reply.send(result);
   });
 
   done();

--- a/src/presentation/http/router/join.ts
+++ b/src/presentation/http/router/join.ts
@@ -1,6 +1,6 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type NoteSettingsService from '@domain/service/noteSettings.js';
-import type { TeamMember } from '@domain/entities/team.js';
+import type { TeamMemberPublic } from '@domain/entities/team.js';
 
 /**
  * Represents AI router options
@@ -55,7 +55,7 @@ const JoinRouter: FastifyPluginCallback<JoinRouterOptions> = (fastify, opts, don
   }, async (request, reply) => {
     const { hash } = request.params;
     const { userId } = request;
-    let result: TeamMember | null = null;
+    let result: TeamMemberPublic | null = null;
 
     try {
       result = await noteSettingsService.addUserToTeamByInvitationHash(hash, userId as number);

--- a/src/repository/storage/postgres/orm/sequelize/teams.ts
+++ b/src/repository/storage/postgres/orm/sequelize/teams.ts
@@ -154,12 +154,12 @@ export default class TeamsSequelizeStorage {
   }
 
   /**
-   * Check if user is note team member
+   * Get team member by user id and note id
    * @param userId - user id to check
    * @param noteId - note id to identify team
-   * @returns returns true if user is team member
+   * @returns return null if user is not in team, teamMember otherwhise
    */
-  public async isUserInTeam(userId: User['id'], noteId: NoteInternalId): Promise<boolean> {
+  public async getTeamMemberByNoteAndUserId(userId: User['id'], noteId: NoteInternalId): Promise<TeamMember | null> {
     const teamMemberShip = await this.model.findOne({
       where: {
         noteId,
@@ -167,7 +167,7 @@ export default class TeamsSequelizeStorage {
       },
     });
 
-    return teamMemberShip !== null;
+    return teamMemberShip;
   }
 
   /**

--- a/src/repository/storage/postgres/orm/sequelize/teams.ts
+++ b/src/repository/storage/postgres/orm/sequelize/teams.ts
@@ -160,14 +160,12 @@ export default class TeamsSequelizeStorage {
    * @returns return null if user is not in team, teamMember otherwhise
    */
   public async getTeamMemberByNoteAndUserId(userId: User['id'], noteId: NoteInternalId): Promise<TeamMember | null> {
-    const teamMemberShip = await this.model.findOne({
+    return await this.model.findOne({
       where: {
         noteId,
         userId,
       },
     });
-
-    return teamMemberShip;
   }
 
   /**

--- a/src/repository/team.repository.ts
+++ b/src/repository/team.repository.ts
@@ -30,13 +30,13 @@ export default class TeamRepository {
   }
 
   /**
-   * Check if user is note team member
+   * Get team member by user id and note id
    * @param userId - user id to check
    * @param noteId - note id to identify team
-   * @returns returns true if user is team member
+   * @returns null if user is not in team, teamMember otherwhise
    */
-  public async isUserInTeam(userId: User['id'], noteId: NoteInternalId): Promise<boolean> {
-    return await this.storage.isUserInTeam(userId, noteId);
+  public async getTeamMemberByNoteAndUserId(userId: User['id'], noteId: NoteInternalId): Promise<TeamMember | null> {
+    return await this.storage.getTeamMemberByNoteAndUserId(userId, noteId);
   }
 
   /**


### PR DESCRIPTION
This PR is related to join route usage on web side (it should not know noteInternalId which now returns on join route)
- added `TeamMemberPublic` entity (team member without team relation id and with `notePublicId` as noteId)
- added shared service method for getting public noteId by NoteInternalid
- made join route return TeamMember with public noteId
- patched repository function
* isUserTeamMember() method deprecated
* Now we can use getTeamMemberByNoteAndUserId because it uses same storage logic (we can check teamMember that we got on null just in domain service)
- get rid of the result : {} decoration in /join route