### PR TITLE
feat(noteHistory): note history implementation

### DIFF
--- a/migrations/tenant/0032-note-history@add-note-history-table.sql
+++ b/migrations/tenant/0032-note-history@add-note-history-table.sql
@@ -1,5 +1,5 @@
 --
--- Name: note-history; Type: TABLE; Schema: public; Owner: codex
+-- Name: note_history; Type: TABLE; Schema: public; Owner: codex
 --
 
 CREATE TABLE IF NOT EXISTS public.note_history (

--- a/migrations/tenant/0032-note-history@add-note-history-table.sql
+++ b/migrations/tenant/0032-note-history@add-note-history-table.sql
@@ -3,11 +3,12 @@
 --
 
 CREATE TABLE IF NOT EXISTS public.note_history (
-  id integer NOT NULL,
+  id SERIAL PRIMARY KEY,
   note_id integer NOT NULL,
   user_id integer,
-  updated_at TIMESTAMP NOT NULL,
-  content json
+  created_at TIMESTAMP NOT NULL,
+  content json,
+  tools jsonb
 );
 
 --
@@ -21,9 +22,9 @@ ALTER TABLE public.note_history
 --
 -- Name: note_history user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS useeeer_id_fkey;
+ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS user_id_fkey;
 ALTER TABLE public.note_history
-  ADD CONSTRAINT useeeer_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
+  ADD CONSTRAINT user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
   ON UPDATE CASCADE ON DELETE CASCADE;
 
-CREATE UNIQUE INDEX note_history_note_id_idx ON public.note_history (note_id);
+CREATE INDEX note_history_note_id_idx ON public.note_history (note_id);

--- a/migrations/tenant/0032-note-history@add-note-history-table.sql
+++ b/migrations/tenant/0032-note-history@add-note-history-table.sql
@@ -21,9 +21,9 @@ ALTER TABLE public.note_history
 --
 -- Name: note_history user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex
 --
-ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS user_id_fkey;
+ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS useeeer_id_fkey;
 ALTER TABLE public.note_history
-  ADD CONSTRAINT user_id_fkey FOREIGN KEY (note_id) REFERENCES public.users(id)
+  ADD CONSTRAINT useeeer_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
   ON UPDATE CASCADE ON DELETE CASCADE;
 
 CREATE UNIQUE INDEX note_history_note_id_idx ON public.note_history (note_id);

--- a/migrations/tenant/0032-note-history@add-note-history-table.sql
+++ b/migrations/tenant/0032-note-history@add-note-history-table.sql
@@ -1,0 +1,29 @@
+--
+-- Name: note-history; Type: TABLE; Schema: public; Owner: codex
+--
+
+CREATE TABLE IF NOT EXISTS public.note_history (
+  id integer NOT NULL,
+  note_id integer NOT NULL,
+  user_id integer,
+  updated_at TIMESTAMP NOT NULL,
+  content json
+);
+
+--
+-- Name: note_history note_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex
+--
+ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS note_id_fkey;
+ALTER TABLE public.note_history
+  ADD CONSTRAINT note_id_fkey FOREIGN KEY (note_id) REFERENCES public.notes(id)
+  ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: note_history user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: codex
+--
+ALTER TABLE public.note_history DROP CONSTRAINT IF EXISTS user_id_fkey;
+ALTER TABLE public.note_history
+  ADD CONSTRAINT user_id_fkey FOREIGN KEY (note_id) REFERENCES public.users(id)
+  ON UPDATE CASCADE ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX note_history_note_id_idx ON public.note_history (note_id);

--- a/src/domain/entities/noteHistory.ts
+++ b/src/domain/entities/noteHistory.ts
@@ -1,4 +1,4 @@
-import type { NoteInternalId, Note } from './note.js';
+import type { NoteInternalId, Note, NotePublicId } from './note.js';
 import type User from './user.js';
 
 export interface NoteHistoryRecord {
@@ -38,4 +38,13 @@ export interface NoteHistoryRecord {
  */
 export type NoteHistoryCreationAttributes = Omit<NoteHistoryRecord, 'id' | 'createdAt'>;
 
+/**
+ * Meta data of the note history record
+ * Used for presentation of the note history recored in web
+ */
 export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content' | 'noteId' | 'tools'>;
+
+/**
+ * Public note history record with note public id instead of note internal id
+ */
+export type NoteHistoryPublic = Omit<NoteHistoryRecord, 'noteId'> & { noteId: NotePublicId };

--- a/src/domain/entities/noteHistory.ts
+++ b/src/domain/entities/noteHistory.ts
@@ -1,0 +1,36 @@
+import type { NoteInternalId, Note } from './note.js';
+import type User from './user.js';
+
+export interface NoteHistoryRecord {
+  /**
+   * Unique identified of note history record
+   */
+  id: number;
+
+  /**
+   * Id of the note those content history is stored
+   */
+  noteId: NoteInternalId;
+
+  /**
+   * User that updated note content
+   */
+  userId: User['id'];
+
+  /**
+   * Timestamp of note update
+   */
+  updatedAt: string;
+
+  /**
+   * Version of note content
+   */
+  content: Note['content'];
+}
+
+/**
+ * Part of note entity used to create new note
+ */
+export type NoteHistoryCreationAttributes = Omit<NoteHistoryRecord, 'id' | 'updatedAt'>;
+
+export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content'>;

--- a/src/domain/entities/noteHistory.ts
+++ b/src/domain/entities/noteHistory.ts
@@ -20,17 +20,22 @@ export interface NoteHistoryRecord {
   /**
    * Timestamp of note update
    */
-  updatedAt: string;
+  createdAt: string;
 
   /**
    * Version of note content
    */
   content: Note['content'];
+
+  /**
+   * Note tools of current version of note content
+   */
+  tools: Note['tools'];
 }
 
 /**
  * Part of note entity used to create new note
  */
-export type NoteHistoryCreationAttributes = Omit<NoteHistoryRecord, 'id' | 'updatedAt'>;
+export type NoteHistoryCreationAttributes = Omit<NoteHistoryRecord, 'id' | 'createdAt'>;
 
-export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content'>;
+export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content' | 'noteId' | 'tools'>;

--- a/src/domain/entities/noteHistory.ts
+++ b/src/domain/entities/noteHistory.ts
@@ -8,7 +8,7 @@ export interface NoteHistoryRecord {
   id: number;
 
   /**
-   * Id of the note those content history is stored
+   * Id of the note whose content history is stored
    */
   noteId: NoteInternalId;
 
@@ -40,7 +40,7 @@ export type NoteHistoryCreationAttributes = Omit<NoteHistoryRecord, 'id' | 'crea
 
 /**
  * Meta data of the note history record
- * Used for presentation of the note history recored in web
+ * Used for presentation of the note history record in web
  */
 export type NoteHistoryMeta = Omit<NoteHistoryRecord, 'content' | 'noteId' | 'tools'>;
 

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -63,7 +63,7 @@ export function init(repositories: Repositories, appConfig: AppConfig): DomainSe
   /**
    * @todo use shared methods for uncoupling repositories unrelated to note service
    */
-  const noteService = new NoteService(repositories.noteRepository, repositories.noteRelationsRepository, repositories.noteVisitsRepository, repositories.editorToolsRepository);
+  const noteService = new NoteService(repositories.noteRepository, repositories.noteRelationsRepository, repositories.noteVisitsRepository, repositories.editorToolsRepository, repositories.noteHistoryRepository);
   const noteVisitsService = new NoteVisitsService(repositories.noteVisitsRepository);
   const authService = new AuthService(
     appConfig.auth.accessSecret,

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -366,6 +366,7 @@ export default class NoteService {
 
   /**
    * Check if content changes are valuable enough to save currently changed note to the history
+   * The sufficiency of changes is determined by the length of the content change
    * @param noteId - id of the note that is currently changed
    * @param content - updated note content
    * @returns - boolean, true if changes are valuable enough, false otherwise

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -55,8 +55,8 @@ export default class NoteService {
    * @param noteRepository - note repository
    * @param noteRelationsRepository - note relationship repository
    * @param noteVisitsRepository - note visits repository
-   * @param editorToolsRepository - editor tools repository
-   * @param noteHistoryRepository - aa
+   * @param editorToolsRepository - editor tools repositoryn
+   * @param noteHistoryRepository - note history repository
    */
   constructor(noteRepository: NoteRepository, noteRelationsRepository: NoteRelationsRepository, noteVisitsRepository: NoteVisitsRepository, editorToolsRepository: EditorToolsRepository, noteHistoryRepository: NoteHistoryRepository) {
     this.noteRepository = noteRepository;
@@ -371,7 +371,7 @@ export default class NoteService {
    * @returns - boolean, true if changes are valuable enough, false otherwise
    */
   public async checkContentDifference(noteId: NoteInternalId, content: Note['content']): Promise<boolean> {
-    const currentlySavedNoteContent = (await this.noteHistoryRepository.getLatestContent(noteId));
+    const currentlySavedNoteContent = (await this.noteHistoryRepository.getLastContentVersion(noteId));
 
     if (currentlySavedNoteContent === undefined) {
       throw new DomainError('No history for the note found');
@@ -412,7 +412,7 @@ export default class NoteService {
    * @param id - id of the note history record
    * @returns full public note history record or raises domain error if record not found
    */
-  public async getHistoryResordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryPublic> {
+  public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryPublic> {
     const noteHistoryRecord = await this.noteHistoryRepository.getHistoryRecordById(id);
 
     if (noteHistoryRecord === null) {

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -142,8 +142,6 @@ export default class NoteService {
      * If content changes are valuable, they will be saved to note history
      */
     if (await this.checkContentDifference(id, content)) {
-      console.log('hiiiiiistory updated');
-
       await this.noteHistoryRepository.createNoteHistoryRecord({
         content,
         userId: userId,
@@ -379,17 +377,11 @@ export default class NoteService {
       return length;
     }, 0);
 
-    console.log('current ccontent length', currentContentLength);
-
     const patchedContentLength = content.blocks.reduce((length, block) => {
       length += JSON.stringify(block.data).length;
 
       return length;
     }, 0);
-
-    console.log('patched content length', patchedContentLength);
-
-    console.log('delta', Math.abs(currentContentLength - patchedContentLength));
 
     if (Math.abs(currentContentLength - patchedContentLength) >= this.valuableContentChangesLength) {
       return true;

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -34,6 +34,9 @@ export default class NoteService {
    */
   public editorToolsRepository: EditorToolsRepository;
 
+  /**
+   * Note history repository
+   */
   public noteHistoryRepository: NoteHistoryRepository;
 
   /**
@@ -42,6 +45,9 @@ export default class NoteService {
    */
   private readonly noteListPortionSize = 30;
 
+  /**
+   * Constant used for checking that content changes are valuable enough to save updated note content to the history
+   */
   private readonly valuableContentChangesLength = 100;
 
   /**
@@ -404,7 +410,7 @@ export default class NoteService {
    * Get concrete history record of the note
    * Used for showing some of the note content versions
    * @param id - id of the note history record
-   * @returns full note history record or raises domain error if record not found
+   * @returns full public note history record or raises domain error if record not found
    */
   public async getHistoryResordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryPublic> {
     const noteHistoryRecord = await this.noteHistoryRepository.getHistoryRecordById(id);
@@ -413,6 +419,10 @@ export default class NoteService {
       throw new DomainError('This version of the note not found');
     }
 
+    /**
+     * Resolve note history record for it to be public
+     * changes noteId from internal to public
+     */
     const noteHistoryPublic = {
       id: noteHistoryRecord.id,
       noteId: await this.getNotePublicIdByInternal(noteHistoryRecord.noteId),

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -147,7 +147,7 @@ export default class NoteService {
     /**
      * If content changes are valuable, they will be saved to note history
      */
-    if (await this.checkContentDifference(id, content)) {
+    if (await this.areContentChangesSignificant(id, content)) {
       await this.noteHistoryRepository.createNoteHistoryRecord({
         content,
         userId: userId,
@@ -371,7 +371,7 @@ export default class NoteService {
    * @param content - updated note content
    * @returns - boolean, true if changes are valuable enough, false otherwise
    */
-  public async checkContentDifference(noteId: NoteInternalId, content: Note['content']): Promise<boolean> {
+  public async areContentChangesSignificant(noteId: NoteInternalId, content: Note['content']): Promise<boolean> {
     const currentlySavedNoteContent = (await this.noteHistoryRepository.getLastContentVersion(noteId));
 
     if (currentlySavedNoteContent === undefined) {

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -8,7 +8,7 @@ import type EditorToolsRepository from '@repository/editorTools.repository.js';
 import type User from '@domain/entities/user.js';
 import type { NoteList } from '@domain/entities/noteList.js';
 import type NoteHistoryRepository from '@repository/noteHistory.repository.js';
-import type { NoteHistoryMeta, NoteHistoryRecord } from '@domain/entities/noteHistory.js';
+import type { NoteHistoryMeta, NoteHistoryRecord, NoteHistoryPublic } from '@domain/entities/noteHistory.js';
 
 /**
  * Note service
@@ -406,13 +406,22 @@ export default class NoteService {
    * @param id - id of the note history record
    * @returns full note history record or raises domain error if record not found
    */
-  public async getHistoryResordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord> {
+  public async getHistoryResordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryPublic> {
     const noteHistoryRecord = await this.noteHistoryRepository.getHistoryRecordById(id);
 
     if (noteHistoryRecord === null) {
       throw new DomainError('This version of the note not found');
     }
 
-    return noteHistoryRecord;
+    const noteHistoryPublic = {
+      id: noteHistoryRecord.id,
+      noteId: await this.getNotePublicIdByInternal(noteHistoryRecord.noteId),
+      userId: noteHistoryRecord.userId,
+      content: noteHistoryRecord.content,
+      tools: noteHistoryRecord.tools,
+      createdAt: noteHistoryRecord.createdAt,
+    };
+
+    return noteHistoryPublic;
   }
 }

--- a/src/domain/service/noteSettings.ts
+++ b/src/domain/service/noteSettings.ts
@@ -165,7 +165,7 @@ export default class NoteSettingsService {
    * Remove team member by userId and noteId
    * @param userId - id of team member
    * @param noteId - note internal id
-   * @returns returns userId if team member was deleted and undefined overwise
+   * @returns returns userId if team member was deleted and undefined otherwise
    */
   public async removeTeamMemberByUserIdAndNoteId(userId: TeamMember['id'], noteId: NoteInternalId): Promise<User['id'] | undefined> {
     return await this.teamRepository.removeTeamMemberByUserIdAndNoteId(userId, noteId);

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -19,6 +19,7 @@ import AIRouter from '@presentation/http/router/ai.js';
 import EditorToolsRouter from './router/editorTools.js';
 import { UserSchema } from './schema/User.js';
 import { NoteSchema } from './schema/Note.js';
+import { HistotyRecordShema, HistoryMetaSchema } from './schema/History.js';
 import { NoteSettingsSchema } from './schema/NoteSettings.js';
 import { OauthSchema } from './schema/OauthSchema.js';
 import Policies from './policies/index.js';
@@ -291,6 +292,8 @@ export default class HttpApi implements Api {
   private addSchema(): void {
     this.server?.addSchema(UserSchema);
     this.server?.addSchema(NoteSchema);
+    this.server?.addSchema(HistotyRecordShema);
+    this.server?.addSchema(HistoryMetaSchema);
     this.server?.addSchema(EditorToolSchema);
     this.server?.addSchema(NoteSettingsSchema);
     this.server?.addSchema(JoinSchemaParams);

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -2067,7 +2067,14 @@ describe('Note API', () => {
         expect(response?.json()).toStrictEqual({ message: expectedMessage });
       } else if (expectedResponse !== undefined) {
         expect(response?.json()).toStrictEqual({
-          noteHistoryRecord: history,
+          noteHistoryRecord: {
+            id: history.id,
+            userId: history.userId,
+            noteId: note.publicId,
+            createdAt: history.createdAt,
+            content: history.content,
+            tools: history.tools,
+          },
         });
       }
     });

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -49,14 +49,14 @@ describe('Note API', () => {
     blocks: [
       {
         id: 'mJDq8YbvqO',
-        type: listTool.name,
+        type: headerTool.name,
         data: {
           text: 'text',
         },
       },
       {
         id: 'DeL0QehzGe',
-        type: headerTool.name,
+        type: paragraphTool.name,
         data: {
           text: 'fdgsfdgfdsg',
           level: 2,
@@ -71,8 +71,8 @@ describe('Note API', () => {
       id: headerTool.id,
     },
     {
-      name: listTool.name,
-      id: listTool.id,
+      name: paragraphTool.name,
+      id: paragraphTool.id,
     },
   ];
 
@@ -83,7 +83,7 @@ describe('Note API', () => {
     blocks: [
       {
         id: 'mJDq8YbvqO',
-        type: listTool.name,
+        type: paragraphTool.name,
         data: {
           text: 'another text here',
         },
@@ -133,16 +133,7 @@ describe('Note API', () => {
       /** Create test note */
       const note = await global.db.insertNote({
         creatorId: user.id,
-        tools: [
-          {
-            name: headerTool.name,
-            id: headerTool.id,
-          },
-          {
-            name: paragraphTool.name,
-            id: paragraphTool.id,
-          },
-        ],
+        tools: DEFAULT_NOTE_TOOLS,
       });
 
       /** Create test note settings */
@@ -239,16 +230,7 @@ describe('Note API', () => {
       /** Create test note */
       const note = await global.db.insertNote({
         creatorId: creator.id,
-        tools: [
-          {
-            name: headerTool.name,
-            id: headerTool.id,
-          },
-          {
-            name: paragraphTool.name,
-            id: paragraphTool.id,
-          },
-        ],
+        tools: DEFAULT_NOTE_TOOLS,
       });
 
       /** Create test note settings */
@@ -1862,7 +1844,7 @@ describe('Note API', () => {
     });
   });
 
-  describe('GET /note/:notePublicId/history', () => {
+  describe.only('GET /note/:notePublicId/history', () => {
     test.each([
       /**
        * User can not edit the note state
@@ -1906,7 +1888,7 @@ describe('Note API', () => {
         expectedMessage: null,
         expectedResponseLength: 2,
       },
-    ])('Should return note history', async ({ authorized, userCanEdit, newNoteContent, expectedMessage, expectedResponseLength }) => {
+    ])('Should return note history preview by note id', async ({ authorized, userCanEdit, newNoteContent, expectedMessage, expectedResponseLength }) => {
       /**
        * Creator of the note
        */
@@ -1937,16 +1919,7 @@ describe('Note API', () => {
         },
         body: {
           content: DEFAULT_NOTE_CONTENT,
-          tools: [
-            {
-              name: headerTool.name,
-              id: headerTool.id,
-            },
-            {
-              name: listTool.name,
-              id: listTool.id,
-            },
-          ],
+          tools: DEFAULT_NOTE_TOOLS,
         },
         url: `/note`,
       });
@@ -2008,7 +1981,7 @@ describe('Note API', () => {
     });
   });
 
-  describe('GET /note/:notePublicId/history', () => {
+  describe('GET /note/:notePublicId/history/:historyId', () => {
     test.each([
       /**
        * User can not edit the note state
@@ -2037,7 +2010,7 @@ describe('Note API', () => {
         userCanEdit: true,
         expectedMessage: null,
       },
-    ])('Should return note history', async ({ authorized, userCanEdit, expectedMessage }) => {
+    ])('Should return certain note history record by it\'s id', async ({ authorized, userCanEdit, expectedMessage }) => {
       const creator = await global.db.insertUser();
 
       const note = await global.db.insertNote({ creatorId: creator.id });

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -65,6 +65,17 @@ describe('Note API', () => {
     ],
   };
 
+  const DEFAULT_NOTE_TOOLS = [
+    {
+      name: headerTool.name,
+      id: headerTool.id,
+    },
+    {
+      name: listTool.name,
+      id: listTool.id,
+    },
+  ];
+
   /**
    * Note content mock inserted if no content passed
    */
@@ -569,6 +580,13 @@ describe('Note API', () => {
         creatorId: creator.id,
       });
 
+      await global.db.insertNoteHistory({
+        userId: creator.id,
+        noteId: note.id,
+        content: DEFAULT_NOTE_CONTENT,
+        tools: DEFAULT_NOTE_TOOLS,
+      });
+
       /** Create test note settings */
       await global.db.insertNoteSetting({
         noteId: note.id,
@@ -690,6 +708,13 @@ describe('Note API', () => {
         },
       ];
 
+      await global.db.insertNoteHistory({
+        userId: user.id,
+        noteId: note.id,
+        content: DEFAULT_NOTE_CONTENT,
+        tools: DEFAULT_NOTE_TOOLS,
+      });
+
       /** Modify the note */
       const response = await global.api?.fakeRequest({
         method: 'PATCH',
@@ -809,16 +834,7 @@ describe('Note API', () => {
        * Specified extra tools
        */
       {
-        noteTools: [
-          {
-            name: headerTool.name,
-            id: headerTool.id,
-          },
-          {
-            name: listTool.name,
-            id: listTool.id,
-          },
-        ],
+        noteTools: DEFAULT_NOTE_TOOLS,
         noteContent: {
           blocks: [
             {
@@ -1432,6 +1448,14 @@ describe('Note API', () => {
         parentId: parentNote.id,
       });
 
+      /** create test note history */
+      await global.db.insertNoteHistory({
+        userId: user.id,
+        noteId: childNote.id,
+        tools: DEFAULT_NOTE_TOOLS,
+        content: DEFAULT_NOTE_CONTENT,
+      });
+
       let response = await global.api?.fakeRequest({
         method: 'PATCH',
         headers: {
@@ -1740,16 +1764,7 @@ describe('Note API', () => {
        * All tools specified correctly
        */
       {
-        noteTools: [
-          {
-            name: headerTool.name,
-            id: headerTool.id,
-          },
-          {
-            name: listTool.name,
-            id: listTool.id,
-          },
-        ],
+        noteTools: DEFAULT_NOTE_TOOLS,
         noteContent: DEFAULT_NOTE_CONTENT,
         expectedStatusCode: 200,
         expectedMessage: null,
@@ -1806,6 +1821,14 @@ describe('Note API', () => {
       await global.db.insertNoteSetting({
         noteId: note.id,
         isPublic: true,
+      });
+
+      /** create test note history */
+      await global.db.insertNoteHistory({
+        userId: user.id,
+        noteId: note.id,
+        tools: DEFAULT_NOTE_TOOLS,
+        content: DEFAULT_NOTE_CONTENT,
       });
 
       let response = await global.api?.fakeRequest({
@@ -2013,16 +2036,7 @@ describe('Note API', () => {
         userId: creator.id,
         noteId: note.id,
         content: DEFAULT_NOTE_CONTENT,
-        tools: [
-          {
-            name: headerTool.name,
-            id: headerTool.id,
-          },
-          {
-            name: listTool.name,
-            id: listTool.id,
-          },
-        ],
+        tools: DEFAULT_NOTE_TOOLS,
       });
 
       const user = await global.db.insertUser();

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -747,24 +747,27 @@ describe('Note API', () => {
   });
 
   describe('POST and PATCH note correctly save note history records', () => {
+    const newContentWithSmallChanges = ALTERNATIVE_NOTE_CONTENT;
+    const newContentWithSignificantChanges = LARGE_NOTE_CONTENT;
+
     test.each([
       /**
        * Patching note content with small changes
        * History should have only one record inserted on note creation
        */
       {
-        newNoteContent: ALTERNATIVE_NOTE_CONTENT,
-        expectedHistoryLength: 1,
+        newNoteContent: newContentWithSmallChanges,
+        historyRecordAdded: false,
       },
       /**
        * Patching note content with large changes
        * History should have two records, inserted on note creation and on note patch
        */
       {
-        newNoteContent: LARGE_NOTE_CONTENT,
-        expectedHistoryLength: 2,
+        newNoteContent: newContentWithSignificantChanges,
+        historyRecordAdded: true,
       },
-    ])('On note creation and note updates history records saves correctly', async ({ newNoteContent, expectedHistoryLength }) => {
+    ])('On note creation and note updates history records saves correctly', async ({ newNoteContent, historyRecordAdded }) => {
       const user = await global.db.insertUser();
 
       const accessToken = global.auth(user.id);
@@ -803,7 +806,11 @@ describe('Note API', () => {
         url: `/note/${noteId}/history`,
       });
 
-      expect(response?.json().noteHistoryMeta).toHaveLength(expectedHistoryLength);
+      if (historyRecordAdded) {
+        expect(response?.json().noteHistoryMeta).toHaveLength(2);
+      } else {
+        expect(response?.json().noteHistoryMeta).toHaveLength(1);
+      }
     });
   });
 

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1762,7 +1762,7 @@ describe('Note API', () => {
   });
 
   describe('PATCH /note/:notePublicId', () => {
-    const tools = [headerTool, listTool];
+    const tools = [headerTool, paragraphTool];
 
     test.each([
       /**

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1864,24 +1864,30 @@ describe('Note API', () => {
 
   describe('GET /note/:notePublicId/history', () => {
     test.each([
-      {
-        authorized: false,
-        userCanEdit: false,
-        newNoteContent: ALTERNATIVE_NOTE_CONTENT,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
+      /**
+       * User can not edit the note state
+       * Should return permission denied response
+       */
       {
         authorized: true,
         userCanEdit: false,
         newNoteContent: ALTERNATIVE_NOTE_CONTENT,
         expectedMessage: 'Permission denied',
       },
+      /**
+       * Unauthorized state
+       * Should return unauthorized response
+       */
       {
         authorized: false,
         userCanEdit: true,
         newNoteContent: ALTERNATIVE_NOTE_CONTENT,
         expectedMessage: 'You must be authenticated to access this resource',
       },
+      /**
+       * New content changes are not valuable enough
+       * Should return one history record, which is saved on note creation
+       */
       {
         authorized: true,
         userCanEdit: true,
@@ -1889,6 +1895,10 @@ describe('Note API', () => {
         expectedMessage: null,
         expectedResponseLength: 1,
       },
+      /**
+       * New content changes are valuable enough
+       * Should return two history records, one from the note creation, another from note content update
+       */
       {
         authorized: true,
         userCanEdit: true,
@@ -2000,34 +2010,34 @@ describe('Note API', () => {
 
   describe('GET /note/:notePublicId/history', () => {
     test.each([
-      {
-        authorized: false,
-        userCanEdit: false,
-        expectedMessage: 'You must be authenticated to access this resource',
-      },
+      /**
+       * User can not edit the note state
+       * Should return permission denied response
+       */
       {
         authorized: true,
         userCanEdit: false,
         expectedMessage: 'Permission denied',
       },
+      /**
+       * Unauthorized state
+       * Should return unauthorized response
+       */
       {
         authorized: false,
         userCanEdit: true,
         expectedMessage: 'You must be authenticated to access this resource',
       },
+      /**
+       * User is authorized and can edit the note
+       * Should return history record that is inserted
+       */
       {
         authorized: true,
         userCanEdit: true,
         expectedMessage: null,
-        expectedResponse: 1,
       },
-      {
-        authorized: true,
-        userCanEdit: true,
-        expectedMessage: null,
-        expectedResponse: 2,
-      },
-    ])('Should return note history', async ({ authorized, userCanEdit, expectedMessage, expectedResponse }) => {
+    ])('Should return note history', async ({ authorized, userCanEdit, expectedMessage }) => {
       const creator = await global.db.insertUser();
 
       const note = await global.db.insertNote({ creatorId: creator.id });
@@ -2065,7 +2075,7 @@ describe('Note API', () => {
 
       if (expectedMessage !== null) {
         expect(response?.json()).toStrictEqual({ message: expectedMessage });
-      } else if (expectedResponse !== undefined) {
+      } else {
         expect(response?.json()).toStrictEqual({
           noteHistoryRecord: {
             id: history.id,

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -106,7 +106,7 @@ describe('Note API', () => {
     blocks: [
       {
         id: 'mJDq8YbvqO',
-        type: listTool.name,
+        type: paragraphTool.name,
         data: {
           text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla.',
         },
@@ -562,13 +562,6 @@ describe('Note API', () => {
         creatorId: creator.id,
       });
 
-      await global.db.insertNoteHistory({
-        userId: creator.id,
-        noteId: note.id,
-        content: DEFAULT_NOTE_CONTENT,
-        tools: DEFAULT_NOTE_TOOLS,
-      });
-
       /** Create test note settings */
       await global.db.insertNoteSetting({
         noteId: note.id,
@@ -689,13 +682,6 @@ describe('Note API', () => {
           id: headerTool.id,
         },
       ];
-
-      await global.db.insertNoteHistory({
-        userId: user.id,
-        noteId: note.id,
-        content: DEFAULT_NOTE_CONTENT,
-        tools: DEFAULT_NOTE_TOOLS,
-      });
 
       /** Modify the note */
       const response = await global.api?.fakeRequest({
@@ -1430,14 +1416,6 @@ describe('Note API', () => {
         parentId: parentNote.id,
       });
 
-      /** create test note history */
-      await global.db.insertNoteHistory({
-        userId: user.id,
-        noteId: childNote.id,
-        tools: DEFAULT_NOTE_TOOLS,
-        content: DEFAULT_NOTE_CONTENT,
-      });
-
       let response = await global.api?.fakeRequest({
         method: 'PATCH',
         headers: {
@@ -1803,14 +1781,6 @@ describe('Note API', () => {
       await global.db.insertNoteSetting({
         noteId: note.id,
         isPublic: true,
-      });
-
-      /** create test note history */
-      await global.db.insertNoteHistory({
-        userId: user.id,
-        noteId: note.id,
-        tools: DEFAULT_NOTE_TOOLS,
-        content: DEFAULT_NOTE_CONTENT,
       });
 
       let response = await global.api?.fakeRequest({

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -1879,25 +1879,15 @@ describe('Note API', () => {
        */
       let userAccessToken: string = '';
 
-      /**
-       * New note posted by creator
-       */
-      let response = await global.api?.fakeRequest({
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${creatorAccessToken}`,
-        },
-        body: {
-          content: DEFAULT_NOTE_CONTENT,
-          tools: DEFAULT_NOTE_TOOLS,
-        },
-        url: `/note`,
+      const note = await global.db.insertNote({
+        creatorId: creator.id,
       });
 
-      /**
-       * Id of the note posted by creator
-       */
-      const noteId = response?.json().id;
+      /** Insert note settings mock */
+      await global.db.insertNoteSetting({
+        noteId: note.id,
+        isPublic: false,
+      });
 
       if (authorized) {
         userAccessToken = global.auth(user.id);
@@ -1911,25 +1901,16 @@ describe('Note API', () => {
         });
       }
 
-      response = await global.api?.fakeRequest({
+      let response = await global.api?.fakeRequest({
         method: 'PATCH',
         headers: {
           authorization: `Bearer ${creatorAccessToken}`,
         },
         body: {
           content: newNoteContent,
-          tools: [
-            {
-              name: headerTool.name,
-              id: headerTool.id,
-            },
-            {
-              name: listTool.name,
-              id: listTool.id,
-            },
-          ],
+          tools: DEFAULT_NOTE_TOOLS,
         },
-        url: `/note/${noteId}`,
+        url: `/note/${note.publicId}`,
       });
 
       /**
@@ -1940,7 +1921,7 @@ describe('Note API', () => {
         headers: {
           authorization: `Bearer ${userAccessToken}`,
         },
-        url: `/note/${noteId}/history`,
+        url: `/note/${note.publicId}/history`,
       });
 
       if (expectedMessage !== null) {

--- a/src/presentation/http/router/note.test.ts
+++ b/src/presentation/http/router/note.test.ts
@@ -717,6 +717,14 @@ describe('Note API', () => {
       expect(response?.json().message).toStrictEqual(expectedMessage);
     });
 
+    // test.each
+    //
+    //
+    //
+    //
+    //
+    //
+
     test.todo('Returns 400 when parentId has incorrect characters and length');
   });
 
@@ -1882,23 +1890,18 @@ describe('Note API', () => {
       if (expectedMessage !== null) {
         expect(response?.json()).toStrictEqual({ message: expectedMessage });
       } else {
-        expect(response?.json().noteHistoryMeta).toMatchObject([
+        expect(response?.json().noteHistoryMeta).toStrictEqual([
           /**
            * First history record created automatically on note insertion
            */
           {
-            id: '1',
-            noteId: note.publicId,
+            id: 1,
             userId: creator.id,
-            content: note.content,
-            tools: note.tools,
           },
           {
             id: history.id,
-            noteId: history.noteId,
             userId: history.userId,
-            content: history.content,
-            tools: history.tools,
+            createdAt: history.createdAt,
           },
         ]);
       }

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -678,7 +678,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
             noteHistoryMeta: {
               type: 'array',
               items: {
-                $ref: 'HistoryMetaSchema#',
+                $ref: 'HistoryMetaSchema',
               },
             },
           },

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -667,6 +667,26 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
         'userCanEdit',
       ],
     },
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      },
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            noteHistoryMeta: {
+              type: 'array',
+              items: {
+                $ref: 'HistoryMetaSchema#',
+              },
+            },
+          },
+        },
+      },
+    },
     preHandler: [
       noteResolver,
     ],
@@ -700,6 +720,26 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
         'authRequired',
         'userCanEdit',
       ],
+    },
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+        historyId: {
+          $ref: 'NoteHistorySchema#/properties/id',
+        },
+      },
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            noteHistoryRecord: {
+              $ref: 'NoteHistorySchema#',
+            },
+          },
+        },
+      },
     },
     preHandler: [
       noteResolver,

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -362,10 +362,11 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const noteId = request.note?.id as number;
     const content = request.body.content;
     const noteTools = request.body.tools;
+    const { userId } = request;
 
     await noteService.validateNoteTools(noteTools, content);
 
-    const note = await noteService.updateNoteContentAndToolsById(noteId, content, noteTools);
+    const note = await noteService.updateNoteContentAndToolsById(noteId, content, noteTools, userId!);
 
     return reply.send({
       updatedAt: note.updatedAt,

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -11,7 +11,7 @@ import { type NotePublic, definePublicNote } from '@domain/entities/notePublic.j
 import type NoteVisitsService from '@domain/service/noteVisits.js';
 import type EditorToolsService from '@domain/service/editorTools.js';
 import type EditorTool from '@domain/entities/editorTools.js';
-import type { NoteHistoryMeta, NoteHistoryRecord } from '@domain/entities/noteHistory.js';
+import type { NoteHistoryMeta, NoteHistoryPublic, NoteHistoryRecord } from '@domain/entities/noteHistory.js';
 
 /**
  * Interface for the note router.
@@ -712,7 +712,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
       historyId: NoteHistoryRecord['id'];
     };
     Reply: {
-      noteHistoryRecord: NoteHistoryRecord;
+      noteHistoryRecord: NoteHistoryPublic;
     } | ErrorResponse;
   }>('/:notePublicId/history/:historyId', {
     config: {

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -365,6 +365,8 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const noteTools = request.body.tools;
     const { userId } = request;
 
+    console.log('i trieeeed very much');
+
     await noteService.validateNoteTools(noteTools, content);
 
     const note = await noteService.updateNoteContentAndToolsById(noteId, content, noteTools, userId!);

--- a/src/presentation/http/router/note.ts
+++ b/src/presentation/http/router/note.ts
@@ -365,8 +365,6 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const noteTools = request.body.tools;
     const { userId } = request;
 
-    console.log('i trieeeed very much');
-
     await noteService.validateNoteTools(noteTools, content);
 
     const note = await noteService.updateNoteContentAndToolsById(noteId, content, noteTools, userId!);
@@ -695,7 +693,7 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
     const noteId = request.note?.id as number;
 
     if (note === null) {
-      return reply.notFound('Note not found');
+      return reply.notAcceptable('Note not found');
     }
 
     return reply.send({
@@ -752,10 +750,10 @@ const NoteRouter: FastifyPluginCallback<NoteRouterOptions> = (fastify, opts, don
      * Check if note exists
      */
     if (note === null) {
-      return reply.notFound('Note not found');
+      return reply.notAcceptable('Note not found');
     }
 
-    const historyRecord = await noteService.getHistoryResordById(historyId);
+    const historyRecord = await noteService.getHistoryRecordById(historyId);
 
     return reply.send({
       noteHistoryRecord: historyRecord,

--- a/src/presentation/http/schema/History.ts
+++ b/src/presentation/http/schema/History.ts
@@ -70,17 +70,19 @@ export const HistoryMetaSchema = {
     'userId',
     'createdAt',
   ],
-  id: {
-    description: 'unique note hisotry record identifier',
-    type: 'number',
-  },
-  userId: {
-    description: 'unique user identifier',
-    type: 'number',
-  },
-  createdAt: {
-    description: 'time, when note history record was created',
-    type: 'string',
-    format: 'date-time',
+  properties: {
+    id: {
+      description: 'unique note hisotry record identifier',
+      type: 'number',
+    },
+    userId: {
+      description: 'unique user identifier',
+      type: 'number',
+    },
+    createdAt: {
+      description: 'time, when note history record was created',
+      type: 'string',
+      format: 'date-time',
+    },
   },
 };

--- a/src/presentation/http/schema/History.ts
+++ b/src/presentation/http/schema/History.ts
@@ -1,0 +1,14 @@
+/**
+ * Note history record shema used for validation and serialization
+ */
+export const HistotyRecordShema = {
+  $id: 'NoteHistorySchema',
+  type: 'object',
+  required: [
+    'content',
+    'id',
+    'userId',
+  ],
+  properties: {
+  },
+};

--- a/src/presentation/http/schema/History.ts
+++ b/src/presentation/http/schema/History.ts
@@ -18,7 +18,7 @@ export const HistotyRecordShema = {
     },
     noteId: {
       description: 'unique note identifier',
-      type: 'number',
+      type: 'string',
     },
     userId: {
       description: 'unique user identifier',
@@ -72,10 +72,6 @@ export const HistoryMetaSchema = {
   ],
   id: {
     description: 'unique note hisotry record identifier',
-    type: 'number',
-  },
-  noteId: {
-    description: 'unique note identifier',
     type: 'number',
   },
   userId: {

--- a/src/presentation/http/schema/History.ts
+++ b/src/presentation/http/schema/History.ts
@@ -8,7 +8,83 @@ export const HistotyRecordShema = {
     'content',
     'id',
     'userId',
+    'createdAt',
+    'tools',
   ],
   properties: {
+    id: {
+      description: 'unique note hisotry record identifier',
+      type: 'number',
+    },
+    noteId: {
+      description: 'unique note identifier',
+      type: 'number',
+    },
+    userId: {
+      description: 'unique user identifier',
+      type: 'number',
+    },
+    createdAt: {
+      description: 'time, when note history record was created',
+      type: 'string',
+      format: 'date-time',
+    },
+    content: {
+      description: 'content of certain version of the note',
+      type: 'object',
+      properties: {
+        time: {
+          type: 'number',
+        },
+        blocks: {
+          type: 'array',
+        },
+        version: {
+          type: 'string',
+        },
+      },
+    },
+    tools: {
+      description: 'list of editor tools objects "toolName": "toolId" for content displaying',
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          name: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+};
+
+export const HistoryMetaSchema = {
+  $id: 'HistoryMetaSchema',
+  type: 'object',
+  required: [
+    'id',
+    'userId',
+    'createdAt',
+  ],
+  id: {
+    description: 'unique note hisotry record identifier',
+    type: 'number',
+  },
+  noteId: {
+    description: 'unique note identifier',
+    type: 'number',
+  },
+  userId: {
+    description: 'unique user identifier',
+    type: 'number',
+  },
+  createdAt: {
+    description: 'time, when note history record was created',
+    type: 'string',
+    format: 'date-time',
   },
 };

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -23,7 +23,7 @@ import FileRepository from './file.repository.js';
 import ObjectStorageRepository from './object.repository.js';
 import NoteVisitsRepository from './noteVisits.repository.js';
 import NoteVisitsStorage from './storage/noteVisits.storage.js';
-
+import NoteHistoryStorage from './storage/noteHistory.storage.js';
 /**
  * Interface for initiated repositories
  */
@@ -118,6 +118,7 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   const s3Storage = new S3Storage(s3Config.accessKeyId, s3Config.secretAccessKey, s3Config.region, s3Config.endpoint);
   const editorToolsStorage = new EditorToolsStorage(orm);
   const noteVisitsStorage = new NoteVisitsStorage(orm);
+  const noteHistoryStorage = new NoteHistoryStorage(orm);
 
   /**
    * Create associations between note and note settings
@@ -142,6 +143,14 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   noteStorage.createAssociationWithNoteVisitsModel(noteVisitsStorage.model);
   noteVisitsStorage.createAssociationWithNoteModel(noteStorage.model);
   noteVisitsStorage.createAssociationWithUserModel(userStorage.model);
+
+  /**
+   * Create associations between note history and note, note history and user storages
+   */
+  noteHistoryStorage.createAssociationWithNoteModel(noteStorage.model);
+  noteHistoryStorage.createAssociationWithUserModel(userStorage.model);
+  noteStorage.createAssociationWithNoteHistoryModel(noteHistoryStorage.model);
+  userStorage.createAssociationWithNoteHistoryModel(noteHistoryStorage.model);
 
   /**
    * Prepare db structure

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -24,6 +24,8 @@ import ObjectStorageRepository from './object.repository.js';
 import NoteVisitsRepository from './noteVisits.repository.js';
 import NoteVisitsStorage from './storage/noteVisits.storage.js';
 import NoteHistoryStorage from './storage/noteHistory.storage.js';
+import NoteHistoryRepository from './noteHistory.repository.js';
+
 /**
  * Interface for initiated repositories
  */
@@ -82,6 +84,8 @@ export interface Repositories {
    * Note Visits repository instance
    */
   noteVisitsRepository: NoteVisitsRepository;
+
+  noteHistoryRepository: NoteHistoryRepository;
 }
 
 /**
@@ -163,6 +167,7 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   await editorToolsStorage.model.sync();
   await noteRelationshipStorage.model.sync();
   await noteVisitsStorage.model.sync();
+  await noteHistoryStorage.model.sync();
 
   /**
    * Create transport instances
@@ -184,6 +189,7 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   const fileRepository = new FileRepository(fileStorage);
   const objectStorageRepository = new ObjectStorageRepository(s3Storage);
   const noteVisitsRepository = new NoteVisitsRepository(noteVisitsStorage);
+  const noteHistoryRepository = new NoteHistoryRepository(noteHistoryStorage);
 
   return {
     noteRepository,
@@ -197,5 +203,6 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
     fileRepository,
     objectStorageRepository,
     noteVisitsRepository,
+    noteHistoryRepository,
   };
 }

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -153,8 +153,6 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
    */
   noteHistoryStorage.createAssociationWithNoteModel(noteStorage.model);
   noteHistoryStorage.createAssociationWithUserModel(userStorage.model);
-  noteStorage.createAssociationWithNoteHistoryModel(noteHistoryStorage.model);
-  userStorage.createAssociationWithNoteHistoryModel(noteHistoryStorage.model);
 
   /**
    * Prepare db structure

--- a/src/repository/noteHistory.repository.ts
+++ b/src/repository/noteHistory.repository.ts
@@ -1,0 +1,22 @@
+import type { NoteHistoryCreationAttributes, NoteHistoryMeta, NoteHistoryRecord } from '@domain/entities/noteHistory.js';
+import type NoteHistoryStorage from '@repository/storage/noteHistory.storage.js';
+
+export default class NoteHistoryRepository {
+  public storage: NoteHistoryStorage;
+
+  constructor(storage: NoteHistoryStorage) {
+    this.storage = storage;
+  }
+
+  public async createNoteHistoryRecord(noteHistory: NoteHistoryCreationAttributes): Promise<NoteHistoryRecord> {
+    return await this.storage.createNoteHistoryRecord(noteHistory);
+  }
+
+  public async getNoteHistoryByNoteId(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryMeta[]> {
+    return await this.storage.getNoteHistoryByNoteId(noteId);
+  }
+
+  public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord | null> {
+    return await this.storage.getHistoryRecordById(id);
+  }
+}

--- a/src/repository/noteHistory.repository.ts
+++ b/src/repository/noteHistory.repository.ts
@@ -19,4 +19,8 @@ export default class NoteHistoryRepository {
   public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord | null> {
     return await this.storage.getHistoryRecordById(id);
   }
+
+  public async getLatestContent(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryRecord['content'] | undefined> {
+    return await this.storage.getLatestContent(noteId);
+  }
 }

--- a/src/repository/noteHistory.repository.ts
+++ b/src/repository/noteHistory.repository.ts
@@ -48,7 +48,7 @@ export default class NoteHistoryRepository {
    * @param noteId - id of the note, whose recent history record we want to see
    * @returns - latest saved content of the note
    */
-  public async getLatestContent(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryRecord['content'] | undefined> {
-    return await this.storage.getLatestContent(noteId);
+  public async getLastContentVersion(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryRecord['content'] | undefined> {
+    return await this.storage.getLastContentVersion(noteId);
   }
 }

--- a/src/repository/noteHistory.repository.ts
+++ b/src/repository/noteHistory.repository.ts
@@ -1,25 +1,53 @@
 import type { NoteHistoryCreationAttributes, NoteHistoryMeta, NoteHistoryRecord } from '@domain/entities/noteHistory.js';
 import type NoteHistoryStorage from '@repository/storage/noteHistory.storage.js';
 
+/**
+ * Note history repository used for data delivery from storage to service
+ */
 export default class NoteHistoryRepository {
+  /**
+   * Note history storage instance
+   */
   public storage: NoteHistoryStorage;
 
   constructor(storage: NoteHistoryStorage) {
     this.storage = storage;
   }
 
+  /**
+   * Creates note hisotry record in storage
+   * @param noteHistory - note history creation attributes
+   * @returns - created note history record
+   */
   public async createNoteHistoryRecord(noteHistory: NoteHistoryCreationAttributes): Promise<NoteHistoryRecord> {
     return await this.storage.createNoteHistoryRecord(noteHistory);
   }
 
+  /**
+   * Gets array of metadata of all saved note history records
+   * @param noteId - id of the note, whose history we want to see
+   * @returns array of metadata of the history records, used for informative presentation of history
+   */
   public async getNoteHistoryByNoteId(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryMeta[]> {
     return await this.storage.getNoteHistoryByNoteId(noteId);
   }
 
+  /**
+   * Get concrete history record by it's id
+   * Used for presentation of certain version of note content saved in history
+   * @param id - id of the history record
+   * @returns full history record or null if there is no record with such an id
+   */
   public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord | null> {
     return await this.storage.getHistoryRecordById(id);
   }
 
+  /**
+   * Gets recent saved history record content
+   * Used for service to check latest сhanges compared to the last saved record
+   * @param noteId - id of the note, whose recent history record we want to see
+   * @returns - latest saved content of the note
+   */
   public async getLatestContent(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryRecord['content'] | undefined> {
     return await this.storage.getLatestContent(noteId);
   }

--- a/src/repository/storage/noteHistory.storage.ts
+++ b/src/repository/storage/noteHistory.storage.ts
@@ -1,0 +1,6 @@
+import NoteHistorySequelizeStorage from './postgres/orm/sequelize/noteHistory.js';
+
+/**
+ * Current note storage
+ */
+export default NoteHistorySequelizeStorage;

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -157,19 +157,6 @@ export default class NoteSequelizeStorage {
   };
 
   /**
-   * create association with note history model
-   * @param model - initialized note history model
-   */
-  public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
-    this.historyModel = model;
-
-    this.model.hasMany(this.historyModel, {
-      foreignKey: 'noteId',
-      as: 'noteHistory',
-    });
-  }
-
-  /**
    * Insert note to database
    * @param options - note creation options
    * @returns - created note

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -141,7 +141,7 @@ export default class NoteSequelizeStorage {
   }
 
   /**
-   * create association with note cisits model
+   * create association with note visits model
    * @param model - initialized note visits model
    */
   public createAssociationWithNoteVisitsModel(model: ModelStatic<NoteVisitsModel>): void {
@@ -156,6 +156,10 @@ export default class NoteSequelizeStorage {
     });
   };
 
+  /**
+   * create association with note history model
+   * @param model - initialized note history model
+   */
   public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
     this.historyModel = model;
 

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -6,6 +6,7 @@ import { UserModel } from '@repository/storage/postgres/orm/sequelize/user.js';
 import type { NoteSettingsModel } from './noteSettings.js';
 import type { NoteVisitsModel } from './noteVisits.js';
 import { DomainError } from '@domain/entities/DomainError.js';
+import type { NoteHistoryModel } from './noteHistory.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -72,6 +73,8 @@ export default class NoteSequelizeStorage {
    * Note visits model in database
    */
   public visitsModel: typeof NoteVisitsModel | null = null;
+
+  public historyModel: typeof NoteHistoryModel | null = null;
 
   /**
    * Database instance
@@ -152,6 +155,15 @@ export default class NoteSequelizeStorage {
       as: 'noteVisits',
     });
   };
+
+  public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
+    this.historyModel = model;
+
+    this.model.hasMany(this.historyModel, {
+      foreignKey: 'noteId',
+      as: 'noteHistory',
+    });
+  }
 
   /**
    * Insert note to database

--- a/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
@@ -1,0 +1,104 @@
+import type { CreationOptional, InferAttributes, InferCreationAttributes, Sequelize, ModelStatic } from 'sequelize';
+import { DataTypes, Model } from 'sequelize';
+import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
+import { NoteModel } from './note.js';
+import { UserModel } from './user.js';
+import type { NoteHistoryCreationAttributes, NoteHistoryRecord, NoteHistoryMeta } from '@domain/entities/noteHistory.js';
+
+export class NoteHistoryModel extends Model<InferAttributes<NoteHistoryModel>, InferCreationAttributes<NoteHistoryModel>> {
+  public declare id: CreationOptional<NoteHistoryRecord['id']>;
+  public declare noteId: NoteHistoryRecord['noteId'];
+  public declare userId: NoteHistoryRecord['userId'];
+  public declare updatedAt: CreationOptional<NoteHistoryRecord['updatedAt']>;
+  public declare content: NoteHistoryRecord['content'];
+}
+
+export default class NoteHistorySequelizeStorage {
+  public model: typeof NoteHistoryModel;
+
+  public userModel: typeof UserModel | null = null;
+
+  public noteModel: typeof NoteModel | null = null;
+
+  private readonly database: Sequelize;
+
+  private readonly tableName = 'note_history';
+
+  constructor({ connection }: Orm) {
+    this.database = connection;
+
+    this.model = NoteHistoryModel.init({
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      noteId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: NoteModel,
+          key: 'id',
+        },
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: UserModel,
+          key: 'id',
+        },
+      },
+      updatedAt: DataTypes.DATE,
+      content: DataTypes.JSON,
+    }, {
+      tableName: this.tableName,
+      sequelize: this.database,
+    });
+  }
+
+  /**
+   * Creates association with user model
+   * @param model - initialized note settings model
+   */
+  public createAssociationWithUserModel(model: ModelStatic<UserModel>): void {
+    this.userModel = model;
+
+    this.model.belongsTo(this.userModel, {
+      foreignKey: 'userId',
+      as: this.userModel.tableName,
+    });
+  }
+
+  /**
+   * Creates association with note model
+   * @param model - initialized note model
+   */
+  public createAssociationWithNoteModel(model: ModelStatic<NoteModel>): void {
+    this.noteModel = model;
+
+    this.model.belongsTo(this.noteModel, {
+      foreignKey: 'noteId',
+      as: this.noteModel.tableName,
+    });
+  }
+
+  public async createNoteHistoryRecord(options: NoteHistoryCreationAttributes): Promise<NoteHistoryRecord> {
+    return await this.model.create({
+      noteId: options.noteId,
+      userId: options.userId,
+      content: options.content,
+    });
+  }
+
+  public async getNoteHistoryByNoteId(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryMeta[]> {
+    return await this.model.findAll({
+      where: { noteId },
+      attributes: ['id', 'noteId', 'userId', 'updatedAt'],
+    });
+  }
+
+  public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord | null> {
+    return await this.model.findByPk(id);
+  }
+}

--- a/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
@@ -5,12 +5,39 @@ import { NoteModel } from './note.js';
 import { UserModel } from './user.js';
 import type { NoteHistoryCreationAttributes, NoteHistoryRecord, NoteHistoryMeta } from '@domain/entities/noteHistory.js';
 
+/**
+ * Note history model instance
+ * Represents structure that is stored in the database
+ */
 export class NoteHistoryModel extends Model<InferAttributes<NoteHistoryModel>, InferCreationAttributes<NoteHistoryModel>> {
+  /**
+   * Unique identified of note history record
+   */
   public declare id: CreationOptional<NoteHistoryRecord['id']>;
+
+  /**
+   * Id of the note those content history is stored
+   */
   public declare noteId: NoteHistoryRecord['noteId'];
+
+  /**
+   * User that updated note content
+   */
   public declare userId: NoteHistoryRecord['userId'];
+
+  /**
+   * Timestamp of the note update
+   */
   public declare createdAt: CreationOptional<NoteHistoryRecord['createdAt']>;
+
+  /**
+   * Certain version of note content
+   */
   public declare content: NoteHistoryRecord['content'];
+
+  /**
+   * Note tools of current version of note content
+   */
   public declare tools: NoteHistoryRecord['tools'];
 }
 
@@ -86,6 +113,11 @@ export default class NoteHistorySequelizeStorage {
     });
   }
 
+  /**
+   * Creates note hisotry record in storage
+   * @param options - all data used for note history record creation
+   * @returns - created note history record
+   */
   public async createNoteHistoryRecord(options: NoteHistoryCreationAttributes): Promise<NoteHistoryRecord> {
     return await this.model.create({
       noteId: options.noteId,
@@ -101,6 +133,11 @@ export default class NoteHistorySequelizeStorage {
     });
   }
 
+  /**
+   * Gets array of metadata of all saved note history records
+   * @param noteId - id of the note, whose history we want to see
+   * @returns array of metadata of the history records
+   */
   public async getNoteHistoryByNoteId(noteId: NoteHistoryRecord['noteId']): Promise<NoteHistoryMeta[]> {
     return await this.model.findAll({
       where: { noteId },
@@ -108,10 +145,20 @@ export default class NoteHistorySequelizeStorage {
     });
   }
 
+  /**
+   * Get concrete history record by it's id
+   * @param id - id of the history record
+   * @returns full history record or null if there is no record with such an id
+   */
   public async getHistoryRecordById(id: NoteHistoryRecord['id']): Promise<NoteHistoryRecord | null> {
     return await this.model.findByPk(id);
   }
 
+  /**
+   * Gets recent saved history record content
+   * @param noteId - id of the note, whose recent history record we want to see
+   * @returns - latest saved content of the note
+   */
   public async getLatestContent(noteId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord['content'] | undefined> {
     const latestHistory = await this.model.findOne({
       where: { noteId },

--- a/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
@@ -16,7 +16,7 @@ export class NoteHistoryModel extends Model<InferAttributes<NoteHistoryModel>, I
   public declare id: CreationOptional<NoteHistoryRecord['id']>;
 
   /**
-   * Id of the note those content history is stored
+   * Id of the note whose content history is stored
    */
   public declare noteId: NoteHistoryRecord['noteId'];
 

--- a/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
+++ b/src/repository/storage/postgres/orm/sequelize/noteHistory.ts
@@ -159,7 +159,7 @@ export default class NoteHistorySequelizeStorage {
    * @param noteId - id of the note, whose recent history record we want to see
    * @returns - latest saved content of the note
    */
-  public async getLatestContent(noteId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord['content'] | undefined> {
+  public async getLastContentVersion(noteId: NoteHistoryRecord['id']): Promise<NoteHistoryRecord['content'] | undefined> {
     const latestHistory = await this.model.findOne({
       where: { noteId },
       order: [['createdAt', 'DESC']],

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -1,9 +1,10 @@
-import type { Sequelize, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
+import type { Sequelize, InferAttributes, InferCreationAttributes, CreationOptional, ModelStatic } from 'sequelize';
 import { literal } from 'sequelize';
 import { Model, DataTypes } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
 import type User from '@domain/entities/user.js';
 import type EditorTool from '@domain/entities/editorTools.js';
+import type { NoteHistoryModel } from './noteHistory.js';
 
 /**
  * Query options for getting user
@@ -116,6 +117,8 @@ export default class UserSequelizeStorage {
    */
   public model: typeof UserModel;
 
+  public historyModel: typeof NoteHistoryModel | null = null;
+
   /**
    * Database instance
    */
@@ -165,6 +168,15 @@ export default class UserSequelizeStorage {
       tableName: this.tableName,
       sequelize: this.database,
       timestamps: false,
+    });
+  }
+
+  public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
+    this.historyModel = model;
+
+    this.model.hasMany(this.historyModel, {
+      foreignKey: 'noteId',
+      as: 'noteHistory',
     });
   }
 

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -175,7 +175,7 @@ export default class UserSequelizeStorage {
     this.historyModel = model;
 
     this.model.hasMany(this.historyModel, {
-      foreignKey: 'noteId',
+      foreignKey: 'userId',
       as: 'noteHistory',
     });
   }

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -4,7 +4,6 @@ import { Model, DataTypes } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
 import type User from '@domain/entities/user.js';
 import type EditorTool from '@domain/entities/editorTools.js';
-import type { NoteHistoryModel } from './noteHistory.js';
 
 /**
  * Query options for getting user
@@ -116,8 +115,6 @@ export default class UserSequelizeStorage {
    * User model in database
    */
   public model: typeof UserModel;
-
-  public historyModel: typeof NoteHistoryModel | null = null;
 
   /**
    * Database instance

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -171,6 +171,10 @@ export default class UserSequelizeStorage {
     });
   }
 
+  /**
+   * create association with note history model
+   * @param model - initialized note history model
+   */
   public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
     this.historyModel = model;
 

--- a/src/repository/storage/postgres/orm/sequelize/user.ts
+++ b/src/repository/storage/postgres/orm/sequelize/user.ts
@@ -1,4 +1,4 @@
-import type { Sequelize, InferAttributes, InferCreationAttributes, CreationOptional, ModelStatic } from 'sequelize';
+import type { Sequelize, InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import { literal } from 'sequelize';
 import { Model, DataTypes } from 'sequelize';
 import type Orm from '@repository/storage/postgres/orm/sequelize/index.js';
@@ -168,19 +168,6 @@ export default class UserSequelizeStorage {
       tableName: this.tableName,
       sequelize: this.database,
       timestamps: false,
-    });
-  }
-
-  /**
-   * create association with note history model
-   * @param model - initialized note history model
-   */
-  public createAssociationWithNoteHistoryModel(model: ModelStatic<NoteHistoryModel>): void {
-    this.historyModel = model;
-
-    this.model.hasMany(this.historyModel, {
-      foreignKey: 'userId',
-      as: 'noteHistory',
     });
   }
 

--- a/src/repository/team.repository.ts
+++ b/src/repository/team.repository.ts
@@ -61,7 +61,7 @@ export default class TeamRepository {
    * Remove team member by id
    * @param userId - id of the team member
    * @param noteId - note internal id
-   * @returns returns userId if team member was deleted and undefined overwise
+   * @returns returns userId if team member was deleted and undefined otherwise
    */
   public async removeTeamMemberByUserIdAndNoteId(userId: TeamMember['id'], noteId: NoteInternalId): Promise<User['id'] | undefined> {
     return await this.storage.removeTeamMemberByUserIdAndNoteId(userId, noteId);

--- a/src/tests/utils/database-helpers.ts
+++ b/src/tests/utils/database-helpers.ts
@@ -34,6 +34,17 @@ const DEFAULT_NOTE_CONTENT = {
   ],
 };
 
+const DEFAULT_NOTE_TOOLS = [
+  {
+    name: 'header',
+    id: '1',
+  },
+  {
+    name: 'paragraph',
+    id: '2',
+  },
+];
+
 /**
  * default type for note mock creation attributes
  */
@@ -127,6 +138,7 @@ export default class DatabaseHelpers {
   /**
    * Inserts note mock to then db
    * Automatically adds note creator to note team
+   * Automatically adds first note history record
    * @param note - note object which contain all info about note
    *
    * If content is not passed, it's value in database would be {}
@@ -135,7 +147,7 @@ export default class DatabaseHelpers {
   public async insertNote(note: NoteMockCreationAttributes): Promise<Note> {
     const content = note.content ?? DEFAULT_NOTE_CONTENT;
     const publicId = note.publicId ?? createPublicId();
-    const tools = note.tools ?? [];
+    const tools = note.tools ?? DEFAULT_NOTE_TOOLS;
 
     const [results, _] = await this.orm.connection.query(`INSERT INTO public.notes ("content", "creator_id", "created_at", "updated_at", "public_id", "tools")
     VALUES ('${JSON.stringify(content)}', ${note.creatorId}, CURRENT_DATE, CURRENT_DATE, '${publicId}', '${JSON.stringify(tools)}'::jsonb)
@@ -151,6 +163,13 @@ export default class DatabaseHelpers {
       userId: createdNote.creatorId,
       noteId: createdNote.id,
       role: 1,
+    });
+
+    await this.insertNoteHistory({
+      userId: createdNote.creatorId,
+      noteId: createdNote.id,
+      content,
+      tools: DEFAULT_NOTE_TOOLS,
     });
 
     return createdNote;

--- a/src/tests/utils/database-helpers.ts
+++ b/src/tests/utils/database-helpers.ts
@@ -34,6 +34,9 @@ const DEFAULT_NOTE_CONTENT = {
   ],
 };
 
+/**
+ * Note tools used in DEFAULT_NOTE_CONTENT constant
+ */
 const DEFAULT_NOTE_TOOLS = [
   {
     name: 'header',

--- a/src/tests/utils/database-helpers.ts
+++ b/src/tests/utils/database-helpers.ts
@@ -153,7 +153,7 @@ export default class DatabaseHelpers {
     const tools = note.tools ?? DEFAULT_NOTE_TOOLS;
 
     const [results, _] = await this.orm.connection.query(`INSERT INTO public.notes ("content", "creator_id", "created_at", "updated_at", "public_id", "tools")
-    VALUES ('${JSON.stringify(content)}', ${note.creatorId}, CURRENT_DATE, CURRENT_DATE, '${publicId}', '${JSON.stringify(tools)}'::jsonb)
+    VALUES ('${JSON.stringify(content)}', ${note.creatorId}, CLOCK_TIMESTAMP(), CLOCK_TIMESTAMP(), '${publicId}', '${JSON.stringify(tools)}'::jsonb)
     RETURNING "id", "content", "creator_id" AS "creatorId", "public_id" AS "publicId", "created_at" AS "createdAt", "updated_at" AS "updatedAt"`,
     {
       type: QueryTypes.INSERT,
@@ -194,7 +194,7 @@ export default class DatabaseHelpers {
     const email = user?.email ?? `${randomPart}@codexmail.com`;
 
     const [results, _] = await this.orm.connection.query(`INSERT INTO public.users ("email", "name", "created_at", "editor_tools")
-    VALUES ('${email}', '${name}', CURRENT_DATE, '${editorTools}'::jsonb)
+    VALUES ('${email}', '${name}', CLOCK_TIMESTAMP(), '${editorTools}'::jsonb)
     RETURNING "id", "email", "name", "editor_tools" AS "editorTools", "created_at" AS "createdAt", "photo"`,
     {
       type: QueryTypes.INSERT,
@@ -209,12 +209,12 @@ export default class DatabaseHelpers {
    * Inserts user session mock to the db
    * @param userSession - userSession object which contain all info about userSession (some info is optional)
    *
-   * refreshTokenExpiresAt should be given as Postgres DATE string (e.g. `CURRENT_DATE + INTERVAL '1 day'`)
+   * refreshTokenExpiresAt should be given as Postgres DATE string (e.g. `CLOCK_TIMESTAMP() + INTERVAL '1 day'`)
    *
-   * if no refreshTokenExpiresAt passed, it's value in database would be `CURRENT_DATE + INTERVAL '1 day'`
+   * if no refreshTokenExpiresAt passed, it's value in database would be `CLOCK_TIMESTAMP() + INTERVAL '1 day'`
    */
   public async insertUserSession(userSession: UserSessionMockCreationAttributes): Promise<UserSessionMockCreationAttributes> {
-    const refreshTokerExpiresAt = userSession.refreshTokenExpiresAt ?? `CURRENT_DATE + INTERVAL '1 day')`;
+    const refreshTokerExpiresAt = userSession.refreshTokenExpiresAt ?? `CLOCK_TIMESTAMP() + INTERVAL '1 day')`;
 
     await this.orm.connection.query(`INSERT INTO public.user_sessions ("user_id", "refresh_token", "refresh_toker_expires_at") VALUES (${userSession.userId}, '${userSession.refreshToker}, '${refreshTokerExpiresAt}')`);
 


### PR DESCRIPTION
## Problem
For now we can complitely grind all note (on web) just by highliting full note and pressing any character
We need to be able to check note content history and get back to the content that was actual some time ago

## Solution
### Add note history table
![image](https://github.com/user-attachments/assets/a5923975-27fe-4def-8f44-484bd1e3949d)

### Add note history storage

### Add note history repository

### Add note history methods for note service
- now service adds new history record on note creation
- now service checks if content changes are valuable enough compared to latest saved history

### Add noteHistoryPublic entity without note internal id's
public noteHistory has `notePublic` id instead of `NoteInternalId`

### Add note history routes for note route
- now we can get full note history meta of the note (for displaying in note history as a list of changes)
- now we can get certain history record with content and display it as a version of the note

### Add note history shema

### Write tests
tests cover states
- Unauthorized user
- User is not in team
- Changes are not valuable for note history record creation
- Changes are valuable enough for saving new history record

solves #268 
