### PR TITLE
chore(note-history): Add converter for note history

### DIFF
--- a/migrations/tenant/0033-note-history@add-initial-note-history-records-for-notes.sql
+++ b/migrations/tenant/0033-note-history@add-initial-note-history-records-for-notes.sql
@@ -1,0 +1,6 @@
+-- Insert note history records for notes that do not have them
+INSERT INTO public.note_history (note_id, user_id, tools, content)
+  SELECT n.id, n.creator_id, n.tools, n.content
+    FROM public.notes n
+    LEFT JOIN public.note_history nh ON n.id = nh.note_id
+      WHERE nh.note_id IS NULL;


### PR DESCRIPTION
## Problem
Now for old notes there are no history records, so user can not patch them
## Solution
Added converter that will add note history records for notes, that does not have them
