### PR TITLE
feat(routes): get all notes by parent note id

### DIFF
--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -236,6 +236,19 @@ export default class NoteService {
       items: await this.noteRepository.getNoteListByUserId(userId, offset, this.noteListPortionSize),
     };
   }
+  
+  /**
+   * Returns note list by parent note id
+   * @param parentId - id of the parent note
+   * @param page - number of current page
+   * @returns list of the notes ordered by time of last visit
+   */
+  public async getNoteListByParentNote(parentNoteId: NoteInternalId, page: number): Promise<NoteList> {
+    const offset = (page - 1) * this.noteListPortionSize;
+    return {
+      items: await this.noteRepository.getNoteListByParentNote(parentNoteId, offset, this.noteListPortionSize),
+    };
+  }
 
   /**
    * Create note relation

--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -236,15 +236,16 @@ export default class NoteService {
       items: await this.noteRepository.getNoteListByUserId(userId, offset, this.noteListPortionSize),
     };
   }
-  
+
   /**
    * Returns note list by parent note id
-   * @param parentId - id of the parent note
+   * @param parentNoteId - id of the parent note
    * @param page - number of current page
    * @returns list of the notes ordered by time of last visit
    */
   public async getNoteListByParentNote(parentNoteId: NoteInternalId, page: number): Promise<NoteList> {
     const offset = (page - 1) * this.noteListPortionSize;
+
     return {
       items: await this.noteRepository.getNoteListByParentNote(parentNoteId, offset, this.noteListPortionSize),
     };

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -207,7 +207,7 @@ export default class HttpApi implements Api {
     await this.server?.register(NoteListRouter, {
       prefix: '/notes',
       noteService: domainServices.noteService,
-      noteSettingsService: domainServices.noteSettingsService
+      noteSettingsService: domainServices.noteSettingsService,
     });
 
     await this.server?.register(JoinRouter, {

--- a/src/presentation/http/http-api.ts
+++ b/src/presentation/http/http-api.ts
@@ -207,6 +207,7 @@ export default class HttpApi implements Api {
     await this.server?.register(NoteListRouter, {
       prefix: '/notes',
       noteService: domainServices.noteService,
+      noteSettingsService: domainServices.noteSettingsService
     });
 
     await this.server?.register(JoinRouter, {

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -4,7 +4,7 @@ import { notEmpty } from '@infrastructure/utils/empty.js';
 import { StatusCodes } from 'http-status-codes';
 import hasProperty from '@infrastructure/utils/hasProperty.js';
 import { getLogger } from '@infrastructure/logging/index.js';
-import type { Note, NotePublicId, NoteInternalId } from '@domain/entities/note.js';
+import type { Note, NotePublicId } from '@domain/entities/note.js';
 
 /**
  * Add middleware for resolve Note by public id and add it to request
@@ -35,10 +35,6 @@ export default function useNoteResolver(noteService: NoteService): {
       const publicId = requestData.notePublicId as NotePublicId;
 
       return await noteService.getNoteByPublicId(publicId);
-    } else if (hasProperty(requestData, 'parentNoteId') && notEmpty(requestData.parentNoteId)) {
-      const noteId = requestData.parentNoteId as NoteInternalId;
-
-      return await noteService.getNoteById(noteId);
     }
   }
 

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -4,7 +4,7 @@ import { notEmpty } from '@infrastructure/utils/empty.js';
 import { StatusCodes } from 'http-status-codes';
 import hasProperty from '@infrastructure/utils/hasProperty.js';
 import { getLogger } from '@infrastructure/logging/index.js';
-import type { Note, NotePublicId } from '@domain/entities/note.js';
+import type { Note, NotePublicId, NoteInternalId } from '@domain/entities/note.js';
 
 /**
  * Add middleware for resolve Note by public id and add it to request
@@ -36,8 +36,12 @@ export default function useNoteResolver(noteService: NoteService): {
 
       return await noteService.getNoteByPublicId(publicId);
     }
+    else if (hasProperty(requestData, 'parentNoteId') && notEmpty(requestData.parentNoteId)) {
+      const noteId = requestData.parentNoteId as NoteInternalId;
+      return await noteService.getNoteById(noteId)
+    }
   }
-
+  
   return {
     noteResolver: async function noteIdResolver(request, reply) {
       let note: Note | undefined;

--- a/src/presentation/http/middlewares/note/useNoteResolver.ts
+++ b/src/presentation/http/middlewares/note/useNoteResolver.ts
@@ -35,13 +35,13 @@ export default function useNoteResolver(noteService: NoteService): {
       const publicId = requestData.notePublicId as NotePublicId;
 
       return await noteService.getNoteByPublicId(publicId);
-    }
-    else if (hasProperty(requestData, 'parentNoteId') && notEmpty(requestData.parentNoteId)) {
+    } else if (hasProperty(requestData, 'parentNoteId') && notEmpty(requestData.parentNoteId)) {
       const noteId = requestData.parentNoteId as NoteInternalId;
-      return await noteService.getNoteById(noteId)
+
+      return await noteService.getNoteById(noteId);
     }
   }
-  
+
   return {
     noteResolver: async function noteIdResolver(request, reply) {
       let note: Note | undefined;

--- a/src/presentation/http/router/noteList.test.ts
+++ b/src/presentation/http/router/noteList.test.ts
@@ -145,7 +145,6 @@ describe('GET /notes?page', () => {
   });
 });
 
-
 describe('GET /notes/:parentNoteId?page', () => {
   test.each([
     /**
@@ -233,7 +232,7 @@ describe('GET /notes/:parentNoteId?page', () => {
       cover: 'DZnvqi63.png',
       isPublic: true,
     });
-    
+
     for (let i = 0; i < portionSize; i++) {
       const note = await global.db.insertNote({
         creatorId: creator.id,
@@ -244,7 +243,7 @@ describe('GET /notes/:parentNoteId?page', () => {
         cover: 'DZnvqi63.png',
         isPublic: true,
       });
-      
+
       await global.db.insertNoteRelation({
         parentId: parentNote.id,
         noteId: note.id,
@@ -272,4 +271,3 @@ describe('GET /notes/:parentNoteId?page', () => {
     }
   });
 });
-

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -6,7 +6,7 @@ import useMemberRoleResolver from '../middlewares/noteSettings/useMemberRoleReso
 import type NoteSettingsService from '@domain/service/noteSettings.js';
 import { definePublicNote, type NotePublic } from '@domain/entities/notePublic.js';
 import type { NoteListPublic } from '@domain/entities/noteList.js';
-import { NoteInternalId } from '@domain/entities/note.js';
+import type { NoteInternalId } from '@domain/entities/note.js';
 
 /**
  * Interface for the noteList router.
@@ -18,10 +18,9 @@ interface NoteListRouterOptions {
   noteService: NoteService;
 
   /**
-  * Note Settings service instance
-  */
+   * Note Settings service instance
+   */
   noteSettingsService: NoteSettingsService;
-
 
 }
 
@@ -113,7 +112,7 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
   fastify.get<{
     Params: {
       parentNoteId: NoteInternalId;
-    }
+    };
     Querystring: {
       page: number;
     };
@@ -129,13 +128,15 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
         notePublicId: {
           $ref: 'NoteSchema#/properties/id',
         },
-      }, querystring: {
+      },
+      querystring: {
         page: {
           type: 'number',
           minimum: 1,
           maximum: 30,
         },
-      }, response: {
+      },
+      response: {
         '2xx': {
           description: 'Query notelist',
           properties: {
@@ -149,14 +150,15 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
           },
         },
       },
-    }, preHandler: [
+    },
+    preHandler: [
       noteResolver,
       noteSettingsResolver,
       memberRoleResolver,
     ],
   }, async (request, reply) => {
-    const { parentNoteId } = await request.params;
-    const { page } = await request.query;
+    const { parentNoteId } = request.params;
+    const { page } = request.query;
 
     const noteList = await noteService.getNoteListByParentNote(parentNoteId, page);
     /**
@@ -169,8 +171,7 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
     };
 
     return reply.send(noteListPublic);
-  })
-
+  });
 
   done();
 };

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -1,7 +1,12 @@
 import type { FastifyPluginCallback } from 'fastify';
 import type NoteService from '@domain/service/note.js';
+import useNoteResolver from '../middlewares/note/useNoteResolver.js';
+import useNoteSettingsResolver from '../middlewares/noteSettings/useNoteSettingsResolver.js';
+import useMemberRoleResolver from '../middlewares/noteSettings/useMemberRoleResolver.js';
+import type NoteSettingsService from '@domain/service/noteSettings.js';
 import { definePublicNote, type NotePublic } from '@domain/entities/notePublic.js';
 import type { NoteListPublic } from '@domain/entities/noteList.js';
+import { NoteInternalId } from '@domain/entities/note.js';
 
 /**
  * Interface for the noteList router.
@@ -11,6 +16,12 @@ interface NoteListRouterOptions {
    * Note service instance
    */
   noteService: NoteService;
+
+  /**
+  * Note Settings service instance
+  */
+  noteSettingsService: NoteSettingsService;
+
 
 }
 
@@ -22,6 +33,25 @@ interface NoteListRouterOptions {
  */
 const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, opts, done) => {
   const noteService = opts.noteService;
+  const noteSettingsService = opts.noteSettingsService;
+
+  /**
+   * Prepare note id resolver middleware
+   * It should be used in routes that accepts note public id
+   */
+  const { noteResolver } = useNoteResolver(noteService);
+
+  /**
+   * Prepare note settings resolver middleware
+   * It should be used to use note settings in middlewares
+   */
+  const { noteSettingsResolver } = useNoteSettingsResolver(noteSettingsService);
+
+  /**
+   * Prepare user role resolver middleware
+   * It should be used to use user role in middlewares
+   */
+  const { memberRoleResolver } = useMemberRoleResolver(noteSettingsService);
 
   /**
    * Get note list ordered by time of last visit
@@ -76,6 +106,70 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
 
     return reply.send(noteListPublic);
   });
+
+  /**
+   * Get note list by parent note
+   */
+  fastify.get<{
+    Params: {
+      parentNoteId: NoteInternalId;
+    }
+    Querystring: {
+      page: number;
+    };
+  }>('/:parentNoteId', {
+    config: {
+      policy: [
+        'notePublicOrUserInTeam',
+      ],
+    },
+    schema: {
+      params: {
+        notePublicId: {
+          $ref: 'NoteSchema#/properties/id',
+        },
+      }, querystring: {
+        page: {
+          type: 'number',
+          minimum: 1,
+          maximum: 30,
+        },
+      }, response: {
+        '2xx': {
+          description: 'Query notelist',
+          properties: {
+            items: {
+              id: { type: 'string' },
+              content: { type: 'string' },
+              createdAt: { type: 'string' },
+              creatorId: { type: 'string' },
+              updatedAt: { type: 'string' },
+            },
+          },
+        },
+      },
+    }, preHandler: [
+      noteResolver,
+      noteSettingsResolver,
+      memberRoleResolver,
+    ],
+  }, async (request, reply) => {
+    const { parentNoteId } = await request.params;
+    const { page } = await request.query;
+
+    const noteList = await noteService.getNoteListByParentNote(parentNoteId, page);
+    /**
+     * Wrapping Notelist for public use
+     */
+    const noteListItemsPublic: NotePublic[] = noteList.items.map(definePublicNote);
+
+    const noteListPublic: NoteListPublic = {
+      items: noteListItemsPublic,
+    };
+
+    return reply.send(noteListPublic);
+  })
+
 
   done();
 };

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -141,11 +141,8 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
           description: 'Query notelist',
           properties: {
             items: {
-              id: { type: 'string' },
-              content: { type: 'string' },
-              createdAt: { type: 'string' },
-              creatorId: { type: 'string' },
-              updatedAt: { type: 'string' },
+              type: 'array',
+              items: { $ref: 'NoteSchema#' },
             },
           },
         },

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -120,6 +120,7 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
   }>('/:parentNoteId', {
     config: {
       policy: [
+        'authRequired',
         'notePublicOrUserInTeam',
       ],
     },

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -139,6 +139,7 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   /**
    * Create associations between note and relations table
    */
+  noteStorage.createAssociationWithNoteRelationsModel(noteRelationshipStorage.model)
   noteRelationshipStorage.createAssociationWithNoteModel(noteStorage.model);
 
   /**

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -139,7 +139,7 @@ export async function init(orm: Orm, s3Config: S3StorageConfig): Promise<Reposit
   /**
    * Create associations between note and relations table
    */
-  noteStorage.createAssociationWithNoteRelationsModel(noteRelationshipStorage.model)
+  noteStorage.createAssociationWithNoteRelationsModel(noteRelationshipStorage.model);
   noteRelationshipStorage.createAssociationWithNoteModel(noteStorage.model);
 
   /**

--- a/src/repository/note.repository.ts
+++ b/src/repository/note.repository.ts
@@ -90,10 +90,10 @@ export default class NoteRepository {
   public async getNotesByIds(noteIds: NoteInternalId[]): Promise<Note[]> {
     return await this.storage.getNotesByIds(noteIds);
   }
-  
+
   /**
    * Gets note list by parent note id
-   * @param parentId - parent note id
+   * @param parentNoteId - parent note id
    * @param offset - number of skipped notes
    * @param limit - number of notes to get
    */

--- a/src/repository/note.repository.ts
+++ b/src/repository/note.repository.ts
@@ -90,4 +90,14 @@ export default class NoteRepository {
   public async getNotesByIds(noteIds: NoteInternalId[]): Promise<Note[]> {
     return await this.storage.getNotesByIds(noteIds);
   }
+  
+  /**
+   * Gets note list by parent note id
+   * @param parentId - parent note id
+   * @param offset - number of skipped notes
+   * @param limit - number of notes to get
+   */
+  public async getNoteListByParentNote(parentNoteId: number, offset: number, limit: number): Promise<Note[]> {
+    return await this.storage.getNoteListByParentNote(parentNoteId, offset, limit);
+  }
 }

--- a/src/repository/storage/postgres/orm/sequelize/note.ts
+++ b/src/repository/storage/postgres/orm/sequelize/note.ts
@@ -6,7 +6,6 @@ import { UserModel } from '@repository/storage/postgres/orm/sequelize/user.js';
 import type { NoteSettingsModel } from './noteSettings.js';
 import type { NoteVisitsModel } from './noteVisits.js';
 import type { NoteRelationsModel } from './noteRelations.js';
-import { DomainError } from '@domain/entities/DomainError.js';
 import type { NoteHistoryModel } from './noteHistory.js';
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -164,8 +163,9 @@ export default class NoteSequelizeStorage {
     this.model.hasMany(this.relationsModel, {
       foreignKey: 'parentId',
       as: 'noteRelations',
-    })
+    });
   }
+
   /**
    * Insert note to database
    * @param options - note creation options
@@ -357,7 +357,7 @@ export default class NoteSequelizeStorage {
 
     return notes;
   }
-  
+
   /**
    * Gets note list by parent note id
    * @param parentId - parent note id
@@ -377,17 +377,16 @@ export default class NoteSequelizeStorage {
       where: { parentId },
       attributes: ['noteId'],
     });
-    
+
     const noteIds = childNotes.map(relation => relation.noteId);
-    
-    
+
     const reply = await this.model.findAll({
       where: {
         id: {
           [Op.in]: noteIds,
         },
       },
-      include:[{
+      include: [{
         model: this.settingsModel,
         as: 'noteSettings',
         attributes: ['cover'],

--- a/src/repository/storage/postgres/orm/sequelize/teams.ts
+++ b/src/repository/storage/postgres/orm/sequelize/teams.ts
@@ -192,7 +192,7 @@ export default class TeamsSequelizeStorage {
 
     return await this.model.findAll({
       where: { noteId },
-      attributes: ['id', 'role'],
+      attributes: ['id', 'role', 'userId'],
       include: {
         model: this.userModel,
         as: 'user',


### PR DESCRIPTION
- This PR adds the api endpoint and tests to get all notes by parent note as described in Issue  Closes #279 .
- Added getNoteListByParentNote() method for NoteService
- Added getNoteListByParentNote() method for NoteRepository
- Added getNoteListByParentNote() method for NoteStorage
- Updated getTeamMembersWithUserInfoByNoteId() method for teamStorage (to include UserId)
- Added tests for the route

