### PR TITLE
fix: adds unique index on note and user id of teams table

### DIFF
--- a/migrations/tenant/0035-note-teams@add-unique-index-on-note-and-user-id.sql
+++ b/migrations/tenant/0035-note-teams@add-unique-index-on-note-and-user-id.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS note_teams_note_id_user_id_unique_idx
+ON public.note_teams (note_id, user_id);

--- a/migrations/tenant/0035-note-teams@add-unique-index-on-note-and-user-id.sql
+++ b/migrations/tenant/0035-note-teams@add-unique-index-on-note-and-user-id.sql
@@ -1,2 +1,19 @@
+-- remove exists duplicate entries from database
+DELETE FROM note_teams
+WHERE id IN (
+  SELECT id
+  FROM (
+    SELECT 
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY note_id, user_id 
+        ORDER BY id
+      ) AS row_num
+    FROM note_teams
+  ) AS duplicates
+  WHERE duplicates.row_num > 1
+);
+
+-- adds unique index
 CREATE UNIQUE INDEX IF NOT EXISTS note_teams_note_id_user_id_unique_idx
 ON public.note_teams (note_id, user_id);

--- a/src/presentation/http/router/noteSettings.test.ts
+++ b/src/presentation/http/router/noteSettings.test.ts
@@ -762,12 +762,6 @@ describe('NoteSettings API', () => {
         creatorId: user.id,
       });
 
-      await global.db.insertNoteTeam({
-        noteId: note.id,
-        userId: user.id,
-        role: MemberRole.Write,
-      });
-
       const accessToken = global.auth(user.id);
 
       const response = await global.api?.fakeRequest({

--- a/src/repository/storage/postgres/orm/sequelize/teams.ts
+++ b/src/repository/storage/postgres/orm/sequelize/teams.ts
@@ -103,6 +103,13 @@ export default class TeamsSequelizeStorage {
       tableName: this.tableName,
       sequelize: this.database,
       timestamps: false,
+      indexes: [
+        // Create a unique index on noteId and userId
+        {
+          unique: true,
+          fields: ['noteId', 'userId'],
+        },
+      ],
     });
   }
 

--- a/src/repository/storage/postgres/orm/sequelize/teams.ts
+++ b/src/repository/storage/postgres/orm/sequelize/teams.ts
@@ -107,7 +107,7 @@ export default class TeamsSequelizeStorage {
         // Create a unique index on noteId and userId
         {
           unique: true,
-          fields: ['noteId', 'userId'],
+          fields: ['note_id', 'user_id'],
         },
       ],
     });


### PR DESCRIPTION
- if we add unique key constraints then it won't allow duplicate entry.
- This PR adds unique index on note and user id of teams model described in Issue Closes #285 