### PR TITLE
feat: add endpoint for fetching user-created notes

### DIFF
--- a/src/domain/service/note.ts
+++ b/src/domain/service/note.ts
@@ -239,6 +239,20 @@ export default class NoteService {
   }
 
   /**
+   * Returns notes created by user, ordered by creation time
+   * @param userId - id of the user
+   * @param page - number of current page
+   * @returns list of the notes ordered by creation time
+   */
+  public async getNotesByCreatorId(userId: User['id'], page: number): Promise<NoteList> {
+    const offset = (page - 1) * this.noteListPortionSize;
+
+    return {
+      items: await this.noteRepository.getNotesByCreatorId(userId, offset, this.noteListPortionSize),
+    };
+  }
+
+  /**
    * Create note relation
    * @param noteId - id of the current note
    * @param parentPublicId - id of the parent note

--- a/src/presentation/http/router/noteList.ts
+++ b/src/presentation/http/router/noteList.ts
@@ -77,6 +77,60 @@ const NoteListRouter: FastifyPluginCallback<NoteListRouterOptions> = (fastify, o
     return reply.send(noteListPublic);
   });
 
+  /**
+   * Get note list created by user, ordered by creation time
+   */
+  fastify.get<{
+    Querystring: {
+      page: number;
+    };
+  }>('/created', {
+    config: {
+      policy: [
+        'authRequired',
+      ],
+    },
+    schema: {
+      querystring: {
+        page: {
+          type: 'number',
+          minimum: 1,
+          maximum: 30,
+        },
+      },
+
+      response: {
+        '2xx': {
+          description: 'Query notelist',
+          properties: {
+            items: {
+              id: { type: 'string' },
+              content: { type: 'string' },
+              createdAt: { type: 'string' },
+              creatorId: { type: 'string' },
+              updatedAt: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  }, async (request, reply) => {
+    const userId = request.userId as number;
+    const page = request.query.page;
+
+    const noteList = await noteService.getNotesByCreatorId(userId, page);
+    /**
+     * Wrapping Notelist for public use
+     */
+    const noteListItemsPublic: NotePublic[] = noteList.items.map(definePublicNote);
+
+    const noteListPublic: NoteListPublic = {
+      items: noteListItemsPublic,
+    };
+
+    return reply.send(noteListPublic);
+  });
+
   done();
 };
 

--- a/src/repository/note.repository.ts
+++ b/src/repository/note.repository.ts
@@ -83,6 +83,16 @@ export default class NoteRepository {
   }
 
   /**
+   * Gets notes created by user, ordered by creation time
+   * @param creatorId - note creator id
+   * @param offset - number of skipped notes
+   * @param limit - number of notes to get
+   */
+  public async getNotesByCreatorId(creatorId: number, offset: number, limit: number): Promise<Note[]> {
+    return await this.storage.getNotesByCreatorId(creatorId, offset, limit);
+  }
+
+  /**
    * Get all notes based on their ids
    * @param noteIds : list of note ids
    * @returns an array of notes


### PR DESCRIPTION
Summary

This pull request introduces a new /created endpoint that allows authenticated users to retrieve a paginated list of their own notes.
