### PR TITLE
fix: cover update fails

### DIFF
--- a/src/domain/service/noteSettings.ts
+++ b/src/domain/service/noteSettings.ts
@@ -143,7 +143,11 @@ export default class NoteSettingsService {
      * In this case we need to remove previous cover
      */
     if (notEmpty(data.cover) && notEmpty(noteSettings.cover)) {
-      await this.shared.fileUploader.deleteFile(noteSettings.cover);
+      try {
+        await this.shared.fileUploader.deleteFile(noteSettings.cover);
+      } catch (error) {
+        this.logger.warn('Previous cover not deleted', { err: error });
+      }
 
       this.logger.debug('Note cover replaced', {
         noteId,


### PR DESCRIPTION
## Problem
When updating a note cover, the API deletes metadata about the previous cover stored in the `files` table. If no such record exists, the program throws an error (`File not found`) and the `cover` field in note settings is not updated.

## What was done
Added error handling for `FileUploader.deleteFile` call in `patchNoteSettingsByNoteId`. Deletion errors are logged as warnings and no longer interrupt the flow.